### PR TITLE
feat(slice): Connect BatonService + Plot Weaver agent stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up buf
+      - name: Set up buf (with token if available to avoid rate limits)
         uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint protos
         run: buf lint
       - name: Generate code

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ terraform.tfstate*
 .vscode/
 .idea/
 
+
+
+# Bazel outputs and symlinks
+/bazel-*
+/bazel-bin
+/bazel-out
+/bazel-testlogs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,15 @@ Thank you for contributing. This repo follows Spec‑Driven Development.
 - Conventional-ish style preferred: feat:, fix:, chore:, docs:, refactor:, test:, infra:
 - Reference FR ids, e.g. "feat(FR-6.1): bootstrap wizard template selection UI"
 
-## Running validation locally (to be expanded)
-- JSON schema validation (ajv): npm run validate:schemas (placeholder)
-- Lint/tests: npm test (placeholder)
-- Firestore rules tests: npm run test:rules (placeholder)
+## Running validation locally
+- Ensure you have Bazelisk installed (brew install bazelisk)
+- Repo pins Bazel via .bazelversion to keep local and CI aligned
+- Typical local flow (mirrors CI):
+  - bazel version
+  - bazel build //...
+  - bazel test //... --test_output=errors
+- When adding imports or generating code, update BUILD files with Gazelle:
+  - bazel run //:gazelle
 
 ## Code of Conduct
 - Be respectful and constructive. Assume positive intent. Focus on clarity and testability.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,3 +9,9 @@ _go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 _go_sdk.download(name = "go_sdk", version = "1.22.5")
 use_repo(_go_sdk, "go_sdk")
 
+
+
+# Import Go module deps from go.mod using rules_go go_deps extension
+_go_deps = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_deps")
+_go_deps.from_file(name = "go_deps", go_mod = "//:go.mod")
+use_repo(_go_deps, "go_deps")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ use_repo(_go_sdk, "go_sdk")
 
 
 
-# Import Go module deps from go.mod using rules_go go_deps extension
-_go_deps = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_deps")
+# Import Go module deps from go.mod using Gazelle's go_deps extension
+_go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 _go_deps.from_file(name = "go_deps", go_mod = "//:go.mod")
 use_repo(_go_deps, "go_deps")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,3 +14,9 @@ use_repo(_go_sdk, "go_sdk")
 # Import Go module deps from go.mod using Gazelle's go_deps extension
 _go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 _go_deps.from_file(go_mod = "//:go.mod")
+use_repo(_go_deps,
+    "com_connectrpc_connect",
+    "com_github_google_uuid",
+    "org_golang_google_protobuf",
+)
+

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,5 +13,4 @@ use_repo(_go_sdk, "go_sdk")
 
 # Import Go module deps from go.mod using Gazelle's go_deps extension
 _go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
-_go_deps.from_file(name = "go_deps", go_mod = "//:go.mod")
-use_repo(_go_deps, "go_deps")
+_go_deps.from_file(go_mod = "//:go.mod")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,0 +1,128 @@
+{
+  "lockFileVersion": 11,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/source.json": "7e3a9adf473e9af076ae485ed649d5641ad50ec5c11718103f34de03170d94ad",
+    "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
+    "https://bcr.bazel.build/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/source.json": "c9320aa53cd1c441d24bd6b716da087ad7e4ff0d9742a9884587596edfe53015",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/source.json": "082ed5f9837901fada8c68c2f3ddc958bb22b6d654f71dd73f3df30d45d4b749",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
+    "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
+    "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/source.json": "0823f097b127e0201ae55d85647c94095edfe27db0431a7ae880dcab08dfaa04",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/source.json": "c73d9ef4268c91bd0c1cd88f1f9dfa08e814b1dbe89b5f594a9f08ba0244d206",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/source.json": "cd74d854bf16a9e002fb2ca7b1a421f4403cda29f824a765acd3a8c56f8d43e6",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/21.7/source.json": "bbe500720421e582ff2d18b0802464205138c06056f443184de39fbb8187b09b",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/source.json": "1f1ba6fea244b616de4a554a0f4983c91a9301640c8fe0dd1d410254115c8430",
+    "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
+    "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
+    "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
+    "https://bcr.bazel.build/modules/rules_go/0.48.0/MODULE.bazel": "d00ebcae0908ee3f5e6d53f68677a303d6d59a77beef879598700049c3980a03",
+    "https://bcr.bazel.build/modules/rules_go/0.48.0/source.json": "895dc1698fd7c5959f92868f3a87156ad1ed8d876668bfa918fa0a623fb1eb22",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
+    "https://bcr.bazel.build/modules/rules_java/7.6.5/source.json": "a805b889531d1690e3c72a7a7e47a870d00323186a9904b36af83aa3d053ee8d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/source.json": "a075731e1b46bc8425098512d038d416e966ab19684a10a34f4741295642fc35",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/source.json": "355cc5737a0f294e560d52b1b7a6492d4fff2caf0bef1a315df5a298fca2d34a",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/source.json": "c2557066e0c0342223ba592510ad3d812d4963b9024831f7f66fd0584dd8c66c",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/source.json": "de77e10ff0ab16acbf54e6b46eecd37a99c5b290468ea1aee6e95eb1affdaed7",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
+    "https://bcr.bazel.build/modules/rules_python/0.22.1/source.json": "57226905e783bae7c37c2dd662be078728e48fa28ee4324a7eabcafb5a43d014",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/source.json": "a96f95e02123320aa015b956f29c00cb818fa891ef823d55148e1a362caacf29",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/source.json": "f1ef7d3f9e0e26d4b23d1c39b5f5de71f584dd7d1b4ef83d9bbba6ec7a6a6459",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
+        "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf",
+            "attributes": {}
+          },
+          "local_config_apple_cc_toolchains": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@platforms//host:extension.bzl%host_platform": {
+      "general": {
+        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
+        "usagesDigest": "meSzxn3DUCcYEhq4HQwExWkWtU4EjriRBQLsZN+Q0SU=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "host_platform": {
+            "bzlFile": "@@platforms//host:extension.bzl",
+            "ruleClassName": "host_platform_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -68,3 +68,28 @@ A multi-agent narrative orchestration engine where the user (the Conductor) dire
 - Review the GraphWrite API and Bootstrap Helper drafts under /docs
 - See plans/execution-plan.md for phased delivery and DoD
 
+## Running the MVP services locally
+
+- Build: `bazel build //...`
+- Test: `bazel test //... --test_output=errors`
+
+Run API (Connect RPC) on port 8080 by default:
+
+- PORT=8080 bazel run //services/api:api
+- Health: curl http://localhost:8080/healthz
+- Issue directive (Connect route):
+  - curl -sS -X POST -H 'Content-Type: application/json' \
+    --data '{"text":"Introduce a betrayal","act":"2","target":"protagonist"}' \
+    http://localhost:8080/libretto.baton.v1.BatonService/IssueDirective
+
+Run Plot Weaver (stub) on a different port to avoid collisions (defaults to 8081):
+
+- PORT=8081 bazel run //services/agents/plotweaver:plotweaver
+- Trigger stub handler:
+  - curl -sS -X POST http://localhost:8081/ | cat
+
+Notes:
+- Both services respect the PORT env var (API default 8080; Plot Weaver default 8081)
+- Current implementation publishes/logs events locally; no real bus or Firestore wiring yet
+
+

--- a/gen/go/libretto/baton/v1/BUILD.bazel
+++ b/gen/go/libretto/baton/v1/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "baton_v1",
+    srcs = ["baton.pb.go"],
+    importpath = "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1",
+    visibility = ["//visibility:public"],
+)
+

--- a/gen/go/libretto/baton/v1/BUILD.bazel
+++ b/gen/go/libretto/baton/v1/BUILD.bazel
@@ -4,6 +4,10 @@ go_library(
     name = "baton_v1",
     srcs = ["baton.pb.go"],
     importpath = "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1",
+    deps = [
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
+++ b/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect",
     deps = [
         "//gen/go/libretto/baton/v1:baton_v1",
-        "@go_deps//:connectrpc.com/connect",
+        "@com_connectrpc_connect//:connectrpc.com/connect",
     ],
     visibility = ["//visibility:public"],
 )

--- a/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
+++ b/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect",
     deps = [
         "//gen/go/libretto/baton/v1:baton_v1",
-        "@com_connectrpc_connect//:connectrpc.com/connect",
+        "@com_connectrpc_connect//:go_default_library",
     ],
     visibility = ["//visibility:public"],
 )

--- a/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
+++ b/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "baton_v1_connect",
+    srcs = ["baton.connect.go"],
+    importpath = "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect",
+    visibility = ["//visibility:public"],
+)
+

--- a/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
+++ b/gen/go/libretto/baton/v1/batonv1connect/BUILD.bazel
@@ -4,6 +4,10 @@ go_library(
     name = "baton_v1_connect",
     srcs = ["baton.connect.go"],
     importpath = "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect",
+    deps = [
+        "//gen/go/libretto/baton/v1:baton_v1",
+        "@go_deps//:connectrpc.com/connect",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/gen/go/libretto/events/v1/BUILD.bazel
+++ b/gen/go/libretto/events/v1/BUILD.bazel
@@ -4,6 +4,11 @@ go_library(
     name = "events_v1",
     srcs = ["events.pb.go"],
     importpath = "github.com/barrynorthern/libretto/gen/go/libretto/events/v1",
+    deps = [
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/gen/go/libretto/events/v1/BUILD.bazel
+++ b/gen/go/libretto/events/v1/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "events_v1",
+    srcs = ["events.pb.go"],
+    importpath = "github.com/barrynorthern/libretto/gen/go/libretto/events/v1",
+    visibility = ["//visibility:public"],
+)
+

--- a/gen/go/libretto/graph/v1/BUILD.bazel
+++ b/gen/go/libretto/graph/v1/BUILD.bazel
@@ -4,6 +4,10 @@ go_library(
     name = "graph_v1",
     srcs = ["graphwrite.pb.go"],
     importpath = "github.com/barrynorthern/libretto/gen/go/libretto/graph/v1",
+    deps = [
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/gen/go/libretto/graph/v1/BUILD.bazel
+++ b/gen/go/libretto/graph/v1/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "graph_v1",
+    srcs = ["graphwrite.pb.go"],
+    importpath = "github.com/barrynorthern/libretto/gen/go/libretto/graph/v1",
+    visibility = ["//visibility:public"],
+)
+

--- a/gen/go/libretto/graph/v1/graphv1connect/BUILD.bazel
+++ b/gen/go/libretto/graph/v1/graphv1connect/BUILD.bazel
@@ -4,6 +4,10 @@ go_library(
     name = "graph_v1_connect",
     srcs = ["graphwrite.connect.go"],
     importpath = "github.com/barrynorthern/libretto/gen/go/libretto/graph/v1/graphv1connect",
+    deps = [
+        "//gen/go/libretto/graph/v1:graph_v1",
+        "@com_connectrpc_connect//:go_default_library",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/gen/go/libretto/graph/v1/graphv1connect/BUILD.bazel
+++ b/gen/go/libretto/graph/v1/graphv1connect/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "graph_v1_connect",
+    srcs = ["graphwrite.connect.go"],
+    importpath = "github.com/barrynorthern/libretto/gen/go/libretto/graph/v1/graphv1connect",
+    visibility = ["//visibility:public"],
+)
+

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,7 @@ module github.com/barrynorthern/libretto
 go 1.22.5
 
 require (
+	connectrpc.com/connect v1.16.1
+	github.com/google/uuid v1.5.0
+	google.golang.org/protobuf v1.33.0
 )
-

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+connectrpc.com/connect v1.16.1 h1:rOdrK/RTI/7TVnn3JsVxt3n028MlTRwmK5Q4heSpjis=
+connectrpc.com/connect v1.16.1/go.mod h1:XpZAduBQUySsb4/KO5JffORVkDI4B6/EYPi7N8xpNZw=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/packages/contracts/events/BUILD.bazel
+++ b/packages/contracts/events/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# Internal contracts/events package
+# Provides the generic Envelope type used for event publishing
+
+go_library(
+    name = "events",
+    srcs = ["envelope.go"],
+    importpath = "github.com/barrynorthern/libretto/packages/contracts/events",
+    visibility = ["//visibility:public"],
+)
+

--- a/packages/contracts/events/envelope.go
+++ b/packages/contracts/events/envelope.go
@@ -1,0 +1,18 @@
+package events
+
+import "time"
+
+// Envelope is the standard event wrapper.
+type Envelope[T any] struct {
+	EventName      string    `json:"eventName"`
+	EventVersion   string    `json:"eventVersion"`
+	EventID        string    `json:"eventId"`
+	OccurredAt     time.Time `json:"occurredAt"`
+	CorrelationID  string    `json:"correlationId"`
+	CausationID    string    `json:"causationId"`
+	IdempotencyKey string    `json:"idempotencyKey"`
+	Producer       string    `json:"producer"`
+	TenantID       string    `json:"tenantId"`
+	Payload        T         `json:"payload"`
+}
+

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure Bazelisk is used and Bazel version matches repo pin
+bazel version
+
+# Keep BUILD files in sync with imports when developing
+# Uncomment locally if you want Gazelle to update BUILD files automatically
+# bazel run //:gazelle
+
+# Build everything like CI
+bazel build //...
+
+# Run tests like CI (show errors)
+bazel test //... --test_output=errors
+

--- a/services/agents/plotweaver/BUILD.bazel
+++ b/services/agents/plotweaver/BUILD.bazel
@@ -4,6 +4,9 @@ go_library(
     name = "plotweaver_lib",
     srcs = ["main.go", "handler.go"],
     importpath = "github.com/barrynorthern/libretto/services/agents/plotweaver",
+    deps = [
+        "@com_github_google_uuid//:go_default_library",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/services/agents/plotweaver/BUILD.bazel
+++ b/services/agents/plotweaver/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "plotweaver_lib",
-    srcs = ["main.go"],
+    srcs = ["main.go", "handler.go"],
     importpath = "github.com/barrynorthern/libretto/services/agents/plotweaver",
     visibility = ["//visibility:private"],
 )

--- a/services/agents/plotweaver/handler.go
+++ b/services/agents/plotweaver/handler.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PubSubMessage struct {
+	Message struct {
+		Data       []byte            `json:"data"`
+		ID         string            `json:"messageId"`
+		Attributes map[string]string `json:"attributes"`
+	} `json:"message"`
+	Subscription string `json:"subscription"`
+}
+
+func publishSceneProposal(ctx context.Context, topic string, publish func(context.Context, string, []byte) error) error {
+	ev := map[string]any{
+		"eventName":      "SceneProposalReady",
+		"eventVersion":   "1.0.0",
+		"eventId":        uuid.NewString(),
+		"occurredAt":     time.Now().UTC().Format(time.RFC3339Nano),
+		"correlationId":  uuid.NewString(),
+		"causationId":    "",
+		"idempotencyKey": uuid.NewString(),
+		"producer":       "plotweaver",
+		"tenantId":       "dev",
+		"payload": map[string]any{
+			"scene_id": uuid.NewString(),
+			"title":    "A turning point",
+			"summary":  "A betrayal changes the course of events.",
+		},
+	}
+	b, _ := json.Marshal(ev)
+	return publish(ctx, topic, b)
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// In MVP, we ignore the contents and always emit a stub proposal
+	ctx := r.Context()
+	_ = publishSceneProposal(ctx, "libretto.dev.scene.proposal.ready.v1", func(ctx context.Context, topic string, data []byte) error {
+		log.Printf("(stub) publish to %s: %s", topic, string(data))
+		return nil
+	})
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+

--- a/services/agents/plotweaver/main.go
+++ b/services/agents/plotweaver/main.go
@@ -5,16 +5,9 @@ import (
 	"net/http"
 )
 
-func handler(w http.ResponseWriter, r *http.Request) {
-	// Placeholder for Pub/Sub push message handling
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("received"))
-}
-
 func main() {
 	http.HandleFunc("/", handler)
 	addr := ":8080"
 	log.Printf("plotweaver listening on %s", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }
-

--- a/services/agents/plotweaver/main.go
+++ b/services/agents/plotweaver/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 )
 
 func main() {
 	http.HandleFunc("/", handler)
-	addr := ":8080"
+	// Configure port via PORT env var (default 8081 to avoid clashing with API)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8081"
+	}
+	addr := ":" + port
 	log.Printf("plotweaver listening on %s", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }

--- a/services/api/BUILD.bazel
+++ b/services/api/BUILD.bazel
@@ -50,5 +50,6 @@ go_test(
     name = "api_test",
     srcs = ["main_test.go"],
     embed = [":api_lib"],
+    size = "small",
 )
 

--- a/services/api/BUILD.bazel
+++ b/services/api/BUILD.bazel
@@ -1,19 +1,41 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
+# Internal publisher package
+
 go_library(
-    name = "api_lib",
-    srcs = [
-        "main.go",
-        "publisher/publisher.go",
-        "server/baton_server.go",
-    ],
-    importpath = "github.com/barrynorthern/libretto/services/api",
+    name = "publisher",
+    srcs = ["publisher/publisher.go"],
+    importpath = "github.com/barrynorthern/libretto/services/api/publisher",
+    visibility = ["//visibility:public"],
+)
+
+# Internal server package implementing Baton service
+
+go_library(
+    name = "server",
+    srcs = ["server/baton_server.go"],
+    importpath = "github.com/barrynorthern/libretto/services/api/server",
     deps = [
         "//gen/go/libretto/baton/v1:baton_v1",
         "//gen/go/libretto/baton/v1/batonv1connect:baton_v1_connect",
         "//gen/go/libretto/events/v1:events_v1",
         "@com_connectrpc_connect//:go_default_library",
         "@com_github_google_uuid//:go_default_library",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Main package
+
+go_library(
+    name = "api_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/barrynorthern/libretto/services/api",
+    deps = [
+        ":publisher",
+        ":server",
+        "//gen/go/libretto/baton/v1/batonv1connect:baton_v1_connect",
+        "@com_connectrpc_connect//:go_default_library",
     ],
     visibility = ["//visibility:private"],
 )

--- a/services/api/BUILD.bazel
+++ b/services/api/BUILD.bazel
@@ -2,7 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "api_lib",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "baton/handler.go",
+        "publisher/publisher.go",
+        "../../packages/contracts/events/envelope.go",
+    ],
     importpath = "github.com/barrynorthern/libretto/services/api",
     visibility = ["//visibility:private"],
 )

--- a/services/api/BUILD.bazel
+++ b/services/api/BUILD.bazel
@@ -4,9 +4,8 @@ go_library(
     name = "api_lib",
     srcs = [
         "main.go",
-        "baton/handler.go",
         "publisher/publisher.go",
-        "../../packages/contracts/events/envelope.go",
+        "server/baton_server.go",
     ],
     importpath = "github.com/barrynorthern/libretto/services/api",
     visibility = ["//visibility:private"],

--- a/services/api/BUILD.bazel
+++ b/services/api/BUILD.bazel
@@ -8,6 +8,13 @@ go_library(
         "server/baton_server.go",
     ],
     importpath = "github.com/barrynorthern/libretto/services/api",
+    deps = [
+        "//gen/go/libretto/baton/v1:baton_v1",
+        "//gen/go/libretto/baton/v1/batonv1connect:baton_v1_connect",
+        "//gen/go/libretto/events/v1:events_v1",
+        "@com_connectrpc_connect//:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/services/api/baton/handler.go
+++ b/services/api/baton/handler.go
@@ -1,0 +1,54 @@
+package baton
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/barrynorthern/libretto/packages/contracts/events"
+	"github.com/google/uuid"
+)
+
+type DirectiveRequest struct {
+	Text   string `json:"text"`
+	Act    string `json:"act,omitempty"`
+	Target string `json:"target,omitempty"`
+}
+
+type Publisher interface {
+	Publish(ctx context.Context, topic string, data []byte) error
+}
+
+func Handler(pub Publisher, topic string, producer string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req DirectiveRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Text == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid payload"})
+			return
+		}
+		payload := map[string]any{"text": req.Text, "act": req.Act, "target": req.Target}
+		ev := events.Envelope[map[string]any]{
+			EventName:      "DirectiveIssued",
+			EventVersion:   "1.0.0",
+			EventID:        uuid.NewString(),
+			OccurredAt:     time.Now().UTC(),
+			CorrelationID:  uuid.NewString(),
+			CausationID:    "",
+			IdempotencyKey: uuid.NewString(),
+			Producer:       producer,
+			TenantID:       "dev",
+			Payload:        payload,
+		}
+		b, _ := json.Marshal(ev)
+		if err := pub.Publish(r.Context(), topic, b); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "publish failed"})
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "queued"})
+	}
+}
+

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -3,9 +3,13 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
+
+	"github.com/barrynorthern/libretto/services/api/baton"
+	"github.com/barrynorthern/libretto/services/api/publisher"
 )
 
-func healthHandler() http.Handler {
+func healthMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -16,7 +20,16 @@ func healthHandler() http.Handler {
 
 func main() {
 	addr := ":8080"
+	topic := os.Getenv("DIRECTIVE_TOPIC")
+	if topic == "" { topic = "libretto.dev.directive.issued.v1" }
+	producer := os.Getenv("PRODUCER")
+	if producer == "" { producer = "api" }
+
+	mux := healthMux()
+	pub := publisher.NopPublisher{}
+	mux.Handle("/baton/directive", baton.Handler(pub, topic, producer))
+
 	log.Printf("api listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, healthHandler()))
+	log.Fatal(http.ListenAndServe(addr, mux))
 }
 

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -20,7 +20,13 @@ func healthMux() *http.ServeMux {
 }
 
 func main() {
-	addr := ":8080"
+	// Configure port via PORT env var (default 8080)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	addr := ":" + port
+
 	topic := os.Getenv("DIRECTIVE_TOPIC")
 	if topic == "" {
 		topic = "libretto.dev.directive.issued.v1"

--- a/services/api/main_test.go
+++ b/services/api/main_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 )
 
-func TestHealthHandler(t *testing.T) {
-	h := healthHandler()
+func TestHealthMux(t *testing.T) {
+	mux := healthMux()
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
@@ -18,4 +18,3 @@ func TestHealthHandler(t *testing.T) {
 		t.Fatalf("expected body 'ok', got %q", rec.Body.String())
 	}
 }
-

--- a/services/api/publisher/publisher.go
+++ b/services/api/publisher/publisher.go
@@ -1,0 +1,20 @@
+package publisher
+
+import (
+	"context"
+	"fmt"
+)
+
+// Publisher publishes events to a bus. In MVP this will be Pub/Sub.
+type Publisher interface {
+	Publish(ctx context.Context, topic string, data []byte) error
+}
+
+// NopPublisher is used in local tests.
+type NopPublisher struct{}
+
+func (NopPublisher) Publish(ctx context.Context, topic string, data []byte) error {
+	fmt.Printf("publish to %s: %d bytes\n", topic, len(data))
+	return nil
+}
+

--- a/services/api/server/baton_server.go
+++ b/services/api/server/baton_server.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"connectrpc.com/connect"
+	batonv1 "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1"
+	"github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect"
+	eventsv1 "github.com/barrynorthern/libretto/gen/go/libretto/events/v1"
+	"github.com/google/uuid"
+)
+
+type Publisher interface {
+	Publish(ctx context.Context, topic string, data []byte) error
+}
+
+type BatonServer struct {
+	batonv1connect.UnimplementedBatonServiceHandler
+	Pub      Publisher
+	Topic    string
+	Producer string
+}
+
+func (s *BatonServer) IssueDirective(ctx context.Context, req *connect.Request[batonv1.IssueDirectiveRequest]) (*connect.Response[batonv1.IssueDirectiveResponse], error) {
+	env := map[string]any{
+		"eventName":      "DirectiveIssued",
+		"eventVersion":   "1.0.0",
+		"eventId":        uuid.NewString(),
+		"occurredAt":     time.Now().UTC().Format(time.RFC3339Nano),
+		"correlationId":  uuid.NewString(),
+		"causationId":    "",
+		"idempotencyKey": uuid.NewString(),
+		"producer":       s.Producer,
+		"tenantId":       "dev",
+		"payload": map[string]any{
+			"text":   req.Msg.GetText(),
+			"act":    req.Msg.GetAct(),
+			"target": req.Msg.GetTarget(),
+		},
+	}
+	b, _ := json.Marshal(env)
+	if err := s.Pub.Publish(ctx, s.Topic, b); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	res := connect.NewResponse(&batonv1.IssueDirectiveResponse{CorrelationId: env["correlationId"].(string)})
+	return res, nil
+}
+

--- a/services/api/server/baton_server.go
+++ b/services/api/server/baton_server.go
@@ -8,7 +8,6 @@ import (
 	"connectrpc.com/connect"
 	batonv1 "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1"
 	"github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect"
-	eventsv1 "github.com/barrynorthern/libretto/gen/go/libretto/events/v1"
 	"github.com/google/uuid"
 )
 
@@ -47,4 +46,3 @@ func (s *BatonServer) IssueDirective(ctx context.Context, req *connect.Request[b
 	res := connect.NewResponse(&batonv1.IssueDirectiveResponse{CorrelationId: env["correlationId"].(string)})
 	return res, nil
 }
-

--- a/spec.md
+++ b/spec.md
@@ -104,6 +104,15 @@ The loss of creative work or state is a catastrophic failure. The system is arch
 
 
 #### 4.4 Build & Repo Strategy (Monorepo)
+
+#### 4.4.1 Service Port Configuration (Local & Cloud Run)
+- All HTTP services (API and agents) shall accept the port via the standard `PORT` environment variable.
+- Default local ports to avoid collisions:
+  - API: 8080
+  - Plot Weaver: 8081
+- Runtimes: Cloud Run sets `PORT` automatically; local dev must set `PORT` explicitly when running multiple services.
+- Future agents should follow this pattern and reserve successive ports as needed; document assignments in README.
+
 - Backend services and agents: Go 1.22+ built with Bazel (rules_go, gazelle). Deployed to Cloud Run with Pub/Sub push.
 - Frontend: Next.js (TypeScript) built initially with package scripts; may be brought under Bazel (rules_nodejs) later.
 - Monorepo: Shared contracts and schemas live in a central package and are code-generated for Go (and TS for the FE) as needed.


### PR DESCRIPTION
- Add Connect BatonService (IssueDirective) in API; publishes DirectiveIssued envelope+payload
- Add Plot Weaver agent stub (Pub/Sub push) emitting SceneProposalReady
- Re-add Bzlmod (rules_go go_deps; Go SDK 1.22.5); add BUILD targets for generated stubs
- Keeps events readable JSON for now; will transition to protojson payloads later
- CI builds/tests via Bazel