### PR TITLE
feat(graphwrite): introduce GraphWrite service skeleton (Connect RPC) with in‑memory Apply and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ A multi-agent narrative orchestration engine where the user (the Conductor) dire
 - Build: `bazel build //...`
 - Test: `bazel test //... --test_output=errors`
 
+### One command (recommended)
+- ./scripts/dev_up.sh
+  - Starts API (8080), Plot Weaver (8081), GraphWrite (8082) — override with API_PORT/PLOT_PORT/GRAPHWRITE_PORT
+  - Stop with Ctrl+C
+- ./scripts/dev_smoke.sh
+  - Runs basic curl smoke checks against all services
+
+### Manual runs (if needed)
 Run API (Connect RPC) on port 8080 by default:
 
 - PORT=8080 bazel run //services/api:api
@@ -88,8 +96,16 @@ Run Plot Weaver (stub) on a different port to avoid collisions (defaults to 8081
 - Trigger stub handler:
   - curl -sS -X POST http://localhost:8081/ | cat
 
+Run GraphWrite (skeleton) on a different port to avoid collisions (defaults to 8082):
+
+- PORT=8082 bazel run //services/graphwrite:graphwrite
+- Apply deltas (Connect route):
+  - curl -sS -X POST -H 'Content-Type: application/json' \
+    --data '{"parentVersionId":"01JROOT","deltas":[{"op":"create","entityType":"Scene","entityId":"sc-1","fields":{"title":"Test"}}]}' \
+    http://localhost:8082/libretto.graph.v1.GraphWriteService/Apply
+
 Notes:
-- Both services respect the PORT env var (API default 8080; Plot Weaver default 8081)
+- All services respect the PORT env var (API 8080; Plot Weaver 8081; GraphWrite 8082)
 - Current implementation publishes/logs events locally; no real bus or Firestore wiring yet
 
 

--- a/scripts/dev_smoke.sh
+++ b/scripts/dev_smoke.sh
@@ -5,21 +5,51 @@ API_PORT="${API_PORT:-8080}"
 PLOT_PORT="${PLOT_PORT:-8081}"
 GRAPHWRITE_PORT="${GRAPHWRITE_PORT:-8082}"
 
-set -x
+PASS=0
+FAIL=0
+
+bold() { printf "\033[1m%s\033[0m" "$1"; }
+green() { printf "\033[32m%s\033[0m" "$1"; }
+red() { printf "\033[31m%s\033[0m" "$1"; }
+
+check() {
+  local name="$1"; shift
+  local cmd=("$@")
+  if output="$(${cmd[@]} 2>/dev/null)"; then
+    echo "$(green "✔") $(bold "$name")"
+  else
+    echo "$(red "✘") $(bold "$name")" >&2
+    echo "$output" >&2 || true
+    FAIL=$((FAIL+1))
+    return 1
+  fi
+  PASS=$((PASS+1))
+}
 
 # API health
-curl -sS "http://localhost:${API_PORT}/healthz" | cat
+check "API health" curl -sS "http://localhost:${API_PORT}/healthz"
 
-# Baton IssueDirective
-curl -sS -X POST -H 'Content-Type: application/json' \
+# Baton IssueDirective (expect correlation_id)
+check "Baton IssueDirective" curl -sS -X POST -H 'Content-Type: application/json' \
   --data '{"text":"Introduce a betrayal","act":"2","target":"protagonist"}' \
-  "http://localhost:${API_PORT}/libretto.baton.v1.BatonService/IssueDirective" | cat
+  "http://localhost:${API_PORT}/libretto.baton.v1.BatonService/IssueDirective"
 
 # Plot Weaver stub
-curl -sS -X POST "http://localhost:${PLOT_PORT}/" | cat
+check "Plot Weaver stub" curl -sS -X POST "http://localhost:${PLOT_PORT}/"
 
-# GraphWrite Apply
-curl -sS -X POST -H 'Content-Type: application/json' \
+# GraphWrite Apply (expect graphVersionId)
+check "GraphWrite Apply" curl -sS -X POST -H 'Content-Type: application/json' \
   --data '{"parentVersionId":"01JROOT","deltas":[{"op":"create","entityType":"Scene","entityId":"sc-1","fields":{"title":"Test"}}]}' \
-  "http://localhost:${GRAPHWRITE_PORT}/libretto.graph.v1.GraphWriteService/Apply" | cat
+  "http://localhost:${GRAPHWRITE_PORT}/libretto.graph.v1.GraphWriteService/Apply"
+
+TOTAL=$((PASS+FAIL))
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo "$(green "All ${TOTAL} checks passed")"
+  exit 0
+else
+  echo "$(red "${FAIL}/${TOTAL} checks failed")"
+  exit 1
+fi
 

--- a/scripts/dev_smoke.sh
+++ b/scripts/dev_smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_PORT="${API_PORT:-8080}"
+PLOT_PORT="${PLOT_PORT:-8081}"
+GRAPHWRITE_PORT="${GRAPHWRITE_PORT:-8082}"
+
+set -x
+
+# API health
+curl -sS "http://localhost:${API_PORT}/healthz" | cat
+
+# Baton IssueDirective
+curl -sS -X POST -H 'Content-Type: application/json' \
+  --data '{"text":"Introduce a betrayal","act":"2","target":"protagonist"}' \
+  "http://localhost:${API_PORT}/libretto.baton.v1.BatonService/IssueDirective" | cat
+
+# Plot Weaver stub
+curl -sS -X POST "http://localhost:${PLOT_PORT}/" | cat
+
+# GraphWrite Apply
+curl -sS -X POST -H 'Content-Type: application/json' \
+  --data '{"parentVersionId":"01JROOT","deltas":[{"op":"create","entityType":"Scene","entityId":"sc-1","fields":{"title":"Test"}}]}' \
+  "http://localhost:${GRAPHWRITE_PORT}/libretto.graph.v1.GraphWriteService/Apply" | cat
+

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Starts the local stack (API, Plot Weaver, GraphWrite) with Bazel on dev ports.
+# Stop with Ctrl+C; all child processes are cleaned up.
+
+API_PORT="${API_PORT:-8080}"
+PLOT_PORT="${PLOT_PORT:-8081}"
+GRAPHWRITE_PORT="${GRAPHWRITE_PORT:-8082}"
+
+pids=()
+
+cleanup() {
+  echo "\nShutting down services..."
+  for pid in "${pids[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+}
+trap cleanup INT TERM EXIT
+
+echo "Starting API on :${API_PORT}"
+PORT="${API_PORT}" bazel run //services/api:api &
+pids+=("$!")
+
+sleep 0.5
+
+echo "Starting Plot Weaver on :${PLOT_PORT}"
+PORT="${PLOT_PORT}" bazel run //services/agents/plotweaver:plotweaver &
+pids+=("$!")
+
+sleep 0.5
+
+echo "Starting GraphWrite on :${GRAPHWRITE_PORT}"
+PORT="${GRAPHWRITE_PORT}" bazel run //services/graphwrite:graphwrite &
+pids+=("$!")
+
+# Simple readiness wait
+sleep 2
+
+echo "\nServices started:"
+echo "- API:          http://localhost:${API_PORT}"
+echo "- Plot Weaver:  http://localhost:${PLOT_PORT}"
+echo "- GraphWrite:   http://localhost:${GRAPHWRITE_PORT}"
+
+echo "\nTip: In a new terminal, run ./scripts/dev_smoke.sh to smoke test endpoints."
+
+echo "\nPress Ctrl+C to stop..."
+
+# Wait on background jobs
+wait -n || true
+

--- a/services/graphwrite/BUILD.bazel
+++ b/services/graphwrite/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+# Server package
+
+go_library(
+    name = "server",
+    srcs = [
+        "server/server.go",
+    ],
+    importpath = "github.com/barrynorthern/libretto/services/graphwrite/server",
+    deps = [
+        "//gen/go/libretto/graph/v1:graph_v1",
+        "//gen/go/libretto/graph/v1/graphv1connect:graph_v1_connect",
+        "@com_connectrpc_connect//:go_default_library",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Binary
+
+go_library(
+    name = "graphwrite_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/barrynorthern/libretto/services/graphwrite",
+    deps = [
+        ":server",
+        "//gen/go/libretto/graph/v1:graph_v1",
+        "//gen/go/libretto/graph/v1/graphv1connect:graph_v1_connect",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "graphwrite",
+    embed = ["graphwrite_lib"],
+    visibility = ["//visibility:public"],
+)
+
+# Tests
+
+go_test(
+    name = "server_test",
+    srcs = [
+        "server/server_test.go",
+    ],
+    embed = ["server"],
+)
+

--- a/services/graphwrite/main.go
+++ b/services/graphwrite/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/barrynorthern/libretto/gen/go/libretto/graph/v1/graphv1connect"
+	gwserver "github.com/barrynorthern/libretto/services/graphwrite/server"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	store := &gwserver.InMemoryStore{}
+	svc := &gwserver.GraphWriteServer{Store: store}
+	mux.Handle(graphv1connect.NewGraphWriteServiceHandler(svc))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8082"
+	}
+	addr := ":" + port
+	log.Printf("graphwrite listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/services/graphwrite/server/server.go
+++ b/services/graphwrite/server/server.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	graphv1 "github.com/barrynorthern/libretto/gen/go/libretto/graph/v1"
+	"github.com/barrynorthern/libretto/gen/go/libretto/graph/v1/graphv1connect"
+)
+
+// InMemoryStore is a minimal stub persistence for Apply.
+type InMemoryStore struct{}
+
+func (s *InMemoryStore) Apply(parent string, deltas []*graphv1.Delta) (string, int32, error) {
+	// Return a fake new version id and count applied
+	return "01JFAKEVERSION", int32(len(deltas)), nil
+}
+
+type GraphWriteServer struct {
+	graphv1connect.UnimplementedGraphWriteServiceHandler
+	Store interface{
+		Apply(parent string, deltas []*graphv1.Delta) (string, int32, error)
+	}
+}
+
+func (s *GraphWriteServer) Apply(ctx context.Context, req *connect.Request[graphv1.ApplyRequest]) (*connect.Response[graphv1.ApplyResponse], error) {
+	version, count, err := s.Store.Apply(req.Msg.GetParentVersionId(), req.Msg.GetDeltas())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	res := connect.NewResponse(&graphv1.ApplyResponse{GraphVersionId: version, Applied: count})
+	return res, nil
+}
+

--- a/services/graphwrite/server/server_test.go
+++ b/services/graphwrite/server/server_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	graphv1 "github.com/barrynorthern/libretto/gen/go/libretto/graph/v1"
+)
+
+type fakeStore struct{ version string; count int32; err error }
+
+func (f fakeStore) Apply(parent string, deltas []*graphv1.Delta) (string, int32, error) {
+	return f.version, f.count, f.err
+}
+
+func TestApplySuccess(t *testing.T) {
+	s := &GraphWriteServer{Store: fakeStore{version: "01JF00", count: 2}}
+	req := connect.NewRequest(&graphv1.ApplyRequest{ParentVersionId: "01JROOT", Deltas: []*graphv1.Delta{{Op: "create"}, {Op: "create"}}})
+	res, err := s.Apply(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got, want := res.Msg.GetGraphVersionId(), "01JF00"; got != want {
+		t.Fatalf("version got %q want %q", got, want)
+	}
+	if got, want := res.Msg.GetApplied(), int32(2); got != want {
+		t.Fatalf("applied got %d want %d", got, want)
+	}
+}
+


### PR DESCRIPTION
## Problem statement
- Today we have a thin vertical slice (Baton API → Plot Weaver stub) but no authoritative path to mutate the Living Narrative graph or produce versioned snapshots.
- Without a GraphWrite service, we can’t:
  - Centralize validation and versioning of graph changes
  - Prepare for Firestore-backed persistence and adjacency index maintenance
  - Provide a stable contract for agents/UI to apply deltas

## What is GraphWrite?
GraphWrite is the single entry point for all graph mutations. It:
- Validates requests (schema + referential integrity in future iterations)
- Applies a batch of deltas as a new immutable GraphVersion
- Enforces idempotency and optimistic concurrency (future)
- Emits versioned deltas and maintains adjacency indexes (future)
This PR introduces a minimal, Connect RPC service that implements the Apply method defined in proto libretto.graph.v1.

References:
- docs/graphwrite-api.md (API contract overview)
- proto/libretto/graph/v1/graphwrite.proto (IDL)
- plans/tickets/00002-wire-pubsub-and-graphwrite-skeleton-for-persistence.md (ticket)

## Solution overview (this PR)
- New service: services/graphwrite
  - Connect handler: GraphWriteService.Apply
  - InMemoryStore stub that returns a fake graphVersionId and counts applied deltas
  - Default port: 8082 (overridable with PORT)
- Bazel targets for server, binary, and tests
- Unit test for Apply success path

This is intentionally minimal to unblock integration and manual testing; Firestore persistence and validations will be added incrementally.

## Scope of changes
- Added
  - services/graphwrite/main.go
  - services/graphwrite/server/server.go
  - services/graphwrite/server/server_test.go
  - services/graphwrite/BUILD.bazel
- No changes to existing API/agent code or deployment config

## Out of scope (deferred)
- Firestore persistence and adjacency index maintenance
- Idempotency keys and optimistic concurrency preconditions
- Schema/ref integrity validation of deltas
- Observability (structured logs, traces, metrics)
- Event emission on write (e.g., VersionCreated)

## Manual review/test steps
- Build and run the service on a non-conflicting port:
  - PORT=8092 bazel run //services/graphwrite:graphwrite
  - Expect log: “graphwrite listening on :8092”
- Send Apply request (Connect JSON):
  - curl -sS -X POST -H 'Content-Type: application/json' --data '{"parentVersionId":"01JROOT","deltas":[{"op":"create","entityType":"Scene","entityId":"sc-1","fields":{"title":"Test"}}]}' http://localhost:8092/libretto.graph.v1.GraphWriteService/Apply
  - Expected response (stub): {"graphVersionId":"01JFAKEVERSION","applied":1}
- Verify unit tests:
  - bazel test //services/graphwrite:server_test --test_output=errors

Optional negative/edge checks:
- Deltas: [] → applied should be 0
- Multiple deltas → applied should equal array length

## Acceptance criteria mapping (ticket 00002)
- GraphWrite Apply returns a new version id and applied count for simple create deltas [met via in-memory stub]
- Service runs locally via Bazel; simple curl works [met]
- Tests added [met]

## Risks and trade-offs
- Risk: diverging from the final Firestore model
  - Mitigation: keep storage behind a Store interface; swap implementation later
- Risk: false sense of completeness
  - Mitigation: ticket explicitly calls this a skeleton; follow-up tickets will add validation, idempotency, and Firestore

## Future work (follow-ups)
- Replace InMemoryStore with Firestore implementation and preconditions
- Validate deltas against model and referential integrity (spec.md 5.4)
- Emit write events and/or update adjacency indexes
- Observability: correlationId propagation, metrics, structured logs
- Integration test: Baton → Agent → GraphWrite happy path (even if temporary)

## Reviewer focus
- API shape (Apply request/response) matches proto and docs
- Handler wiring and Bazel targets are idiomatic and minimal
- Test verifies the core behavior without overfitting to the stub

## Changelog
- Added GraphWrite service skeleton (Connect RPC), in-memory Apply, and tests
- Bazel targets for build/test/run
