### PR TITLE
feat(api/agents/graphwrite): env-gated publisher selection, Plot Weaver /push handler, and GraphWrite Apply validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,12 @@ jobs:
           if [ -f dev_up.pid ]; then
             kill $(cat dev_up.pid) || true
           fi
+
+      - name: Upload dev logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-logs
+          path: dev_up.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,31 @@ jobs:
       - name: Test all targets
         run: bazel test //... --test_output=errors
 
+
+
+  smoke-matrix:
+    runs-on: ubuntu-latest
+    needs: [bazel-build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+      - name: Build binaries (for faster run)
+        run: bazel build //services/api:api //services/agents/plotweaver:plotweaver //services/graphwrite:graphwrite
+      - name: Start services in background (NOP)
+        run: |
+          nohup ./scripts/dev_up.sh > dev_up.log 2>&1 &
+          echo $! > dev_up.pid
+          sleep 5
+      - name: Smoke (NOP)
+        run: ./scripts/dev_smoke.sh
+      - name: Smoke (PUBSUB)
+        run: PUBSUB_ENABLED=true ./scripts/dev_smoke.sh
+      - name: Cleanup
+        if: always()
+        run: |
+          cat dev_up.log || true
+          if [ -f dev_up.pid ]; then
+            kill $(cat dev_up.pid) || true
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,18 @@ Thank you for contributing. This repo follows Spec‑Driven Development.
 - Reference FR ids, e.g. "feat(FR-6.1): bootstrap wizard template selection UI"
 
 ## Running validation locally
-- Ensure you have Bazelisk installed (brew install bazelisk)
-- Repo pins Bazel via .bazelversion to keep local and CI aligned
+- Prefer Make targets for all local workflows. Scripts are implementation details.
+- Ensure you have Bazelisk installed (brew install bazelisk). Bazel is pinned via .bazelversion.
 - Typical local flow (mirrors CI):
-  - bazel version
-  - bazel build //...
-  - bazel test //... --test_output=errors
+  - make build
+  - make test
+- Local dev stack:
+  - make dev-up      # starts API, Plot Weaver, GraphWrite on dev ports; Ctrl+C to stop
+  - make dev-smoke   # runs smoke checks (colorized pass/fail)
+  - make matrix      # runs smoke in both modes: default (NOP) and PUBSUB_ENABLED=true
+- Env overrides:
+  - API_PORT=8090 PLOT_PORT=8091 GRAPHWRITE_PORT=8092 make dev-up
+  - PUBSUB_ENABLED=true make dev-smoke
 - When adding imports or generating code, update BUILD files with Gazelle:
   - bazel run //:gazelle
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ dev-up:
 dev-smoke:
 	./scripts/dev_smoke.sh
 
-
 matrix:
 	./scripts/dev_matrix.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Simple dev targets for local workflow
 
-.PHONY: build test dev-up dev-smoke dev-down
+.PHONY: build test dev-up dev-smoke dev-down matrix
 
 build:
 	bazel build //...
@@ -13,6 +13,10 @@ dev-up:
 
 dev-smoke:
 	./scripts/dev_smoke.sh
+
+
+matrix:
+	./scripts/dev_matrix.sh
 
 dev-down:
 	pkill -f bazel-bin/services/api/api_/api || true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
 # Simple dev targets for local workflow
+# Make targets for local development and CI-friendly workflows
+
+help:
+	@echo "Available targets:"
+	@echo "  build       - bazel build //..."
+	@echo "  test        - bazel test //... --test_output=errors"
+	@echo "  dev-up      - start API, Plot Weaver, GraphWrite (readiness checks)"
+	@echo "  dev-smoke   - run smoke checks against local services"
+	@echo "  matrix      - run smoke in NOP and PUBSUB modes"
+	@echo "  dev-down    - stop local services (best-effort)"
+	@echo "Environment overrides: API_PORT, PLOT_PORT, GRAPHWRITE_PORT, PUBSUB_ENABLED"
+	@echo "Examples: API_PORT=8090 PLOT_PORT=8091 GRAPHWRITE_PORT=8092 make dev-up"
+	@echo "          PUBSUB_ENABLED=true make dev-smoke"
+
+
 
 .PHONY: build test dev-up dev-smoke dev-down matrix
 

--- a/README.md
+++ b/README.md
@@ -70,39 +70,27 @@ A multi-agent narrative orchestration engine where the user (the Conductor) dire
 
 ## Running the MVP services locally
 
-- Build: `bazel build //...`
-- Test: `bazel test //... --test_output=errors`
+- Build: `make build`
+- Test: `make test`
 
 ### One command (recommended)
-- ./scripts/dev_up.sh
-  - Starts API (8080), Plot Weaver (8081), GraphWrite (8082) — override with API_PORT/PLOT_PORT/GRAPHWRITE_PORT
+- `make dev-up`
+  - Starts API (8080), Plot Weaver (8081), GraphWrite (8082)
+  - Override with env: `API_PORT=8090 PLOT_PORT=8091 GRAPHWRITE_PORT=8092 make dev-up`
+  - Publisher selection: set `PUBSUB_ENABLED=true` to select Pub/Sub publisher (otherwise NOP)
   - Stop with Ctrl+C
-- ./scripts/dev_smoke.sh
-  - Runs basic curl smoke checks against all services
+- `make dev-smoke`
+  - Runs smoke checks; API logs indicate `publisher=pubsub|nop`
+
+### Verification matrix
+- `make matrix`
+  - Runs smoke checks twice: once with default (NOP) and once with `PUBSUB_ENABLED=true`
 
 ### Manual runs (if needed)
-Run API (Connect RPC) on port 8080 by default:
-
-- PORT=8080 bazel run //services/api:api
-- Health: curl http://localhost:8080/healthz
-- Issue directive (Connect route):
-  - curl -sS -X POST -H 'Content-Type: application/json' \
-    --data '{"text":"Introduce a betrayal","act":"2","target":"protagonist"}' \
-    http://localhost:8080/libretto.baton.v1.BatonService/IssueDirective
-
-Run Plot Weaver (stub) on a different port to avoid collisions (defaults to 8081):
-
-- PORT=8081 bazel run //services/agents/plotweaver:plotweaver
-- Trigger stub handler:
-  - curl -sS -X POST http://localhost:8081/ | cat
-
-Run GraphWrite (skeleton) on a different port to avoid collisions (defaults to 8082):
-
-- PORT=8082 bazel run //services/graphwrite:graphwrite
-- Apply deltas (Connect route):
-  - curl -sS -X POST -H 'Content-Type: application/json' \
-    --data '{"parentVersionId":"01JROOT","deltas":[{"op":"create","entityType":"Scene","entityId":"sc-1","fields":{"title":"Test"}}]}' \
-    http://localhost:8082/libretto.graph.v1.GraphWriteService/Apply
+Prefer Make targets above. For reference only:
+- API: `PORT=8080 bazel run //services/api:api`
+- Plot Weaver: `PORT=8081 bazel run //services/agents/plotweaver:plotweaver`
+- GraphWrite: `PORT=8082 bazel run //services/graphwrite:graphwrite`
 
 Notes:
 - All services respect the PORT env var (API 8080; Plot Weaver 8081; GraphWrite 8082)

--- a/docs/adr/0009-agent-orchestration-seams-and-langgraph-sidecar.md
+++ b/docs/adr/0009-agent-orchestration-seams-and-langgraph-sidecar.md
@@ -1,0 +1,139 @@
+# ADR 0009: Agent Orchestration Strategy — API Seams + LangGraph Sidecar for MVP
+
+Status: Accepted
+Date: 2025-08-16
+Owners: barrynorthern
+Reviewers: Augment Agent
+Supersedes: ADR 0002 (Orchestration Choice for MVP)
+Related: ADR 0001 (Data Store and Graph Abstraction), ADR 0005 (Events and Idempotency), ADR 0006 (Backend Language and Runtime), ADR 0008 (IDL and RPC)
+
+## Context
+- We are building an agentic AI product with a Go backend and Bazel builds, prioritizing a thin, reliable vertical slice.
+- The agentic runtime landscape is evolving. Mature agent runtimes (e.g., LangGraph) are Python/TS-first; Go-native options are lighter-weight.
+- We want to:
+  - Establish durable API seams so orchestration is swappable.
+  - Use a sensible off-the-shelf solution for MVP orchestration to reduce time-to-value.
+  - Prefer Go for application code and plumbing; accept ring-fenced Python for specialized runtime pieces where justified.
+  - Keep the door open to adopt Temporal for durable execution in later iterations.
+- Previous decision (ADR 0002) selected Google Cloud Workflows for MVP. We are revising based on updated requirements and evaluation of agentic runtimes.
+
+## Decision
+- Define clear, versioned internal interfaces for agent orchestration and keep them language- and vendor-neutral.
+- For the MVP, implement orchestration in a ring-fenced Python sidecar using LangGraph (production-ready agent runtime with stateful graph semantics and checkpointing).
+- Keep Go as the system-of-record and external API surface; the Python sidecar is invoked via a strict RPC boundary (gRPC preferred; HTTP/JSON acceptable), with versioned schemas and strong isolation.
+- Defer integrating Temporal until later; design the seams (IDs, idempotency, step boundaries, cancellation semantics) to enable a straightforward refactor to Temporal when warranted.
+
+## Decision Drivers
+- Speed to value: deliver a reliable, debuggable agent graph quickly.
+- Reliability and observability: benefit from LangGraph's graph semantics and checkpointing now, with OTEL-friendly tracing from day one.
+- Optionality: neutral seams let us swap/augment runtime (e.g., Temporal later) without rewriting product code.
+- Team focus: keep Go app code and product features first; "framework-y" complexity is isolated.
+
+## Architecture and API Seams
+
+### High-level topology
+- Go application services (APIs, tools, business logic)
+- Agent Orchestration Service (Python/LangGraph sidecar)
+- Shared data plane (Postgres, vector store such as pgvector/Qdrant)
+- Observability: OpenTelemetry traces/metrics/logs correlated across services
+
+### RPC boundary (stable, versioned)
+- Transport: gRPC (per ADR 0008); fallback HTTP/JSON allowed when necessary
+- Versioning: v1 namespace; additive changes only; explicit deprecation policy
+- Contracts live under: idl/agent/v1 (protobuf and/or OpenAPI); codegen for Go and Python stubs
+
+### Core messages (shape/semantics)
+- StartAgentRequest
+  - workflow_id (externally stable), session_id, actor/user_id
+  - input (structured), tool_caps, budget_limits, metadata (tenant, PII flags)
+- StartAgentResponse
+  - run_id (opaque), initial_state_digest, accepted=true/false, errors[]
+- Streamed events (server stream or webhook callback)
+  - Event types: LlmStep, ToolCallRequested, ToolCallResult, HumanApprovalRequested, StateCheckpointed, RunCompleted, RunFailed, Cancelled
+  - Every event carries: run_id, sequence_no, idempotency_key, trace_id/span_id, timestamp
+- Control plane
+  - CancelRun(run_id), GetRun(run_id), ResumeRun(run_id, payload), ListRuns(query)
+- Error semantics
+  - Clear retryability contract (retryable vs terminal); idempotency per step (see ADR 0005)
+
+### Go-side interfaces (keep narrow)
+- AgentClient: Start, Stream, Cancel, Resume, Get
+- ToolServer: Implements Tools invoked by LangGraph via RPC callbacks (strict JSON schema, timeouts)
+- CheckpointReader: Go reads snapshots for product UI/analytics (no direct writes into sidecar state)
+- Tracing: OTEL everywhere; shared trace propagation (traceparent)
+
+### Python sidecar contracts
+- Deterministic graph nodes with explicit step boundaries and checkpointing
+- Idempotent tool calls (idempotency_key provided; sidecar must pass it through)
+- Configurable policies (timeouts, budgets, safety filters)
+- Persistent store for checkpoints (Postgres) and run metadata
+
+## Rationale and Trade-offs
+- Not Go-only: Building graph semantics, checkpointing, retries, and human-in-the-loop to production reliability would delay the MVP.
+- LangGraph choice: Currently the most production-ready agent runtime for stateful graphs and recovery.
+- Ring-fenced Python: Keeps the rest of the stack in Go; orchestration is isolated, replaceable, and operationally constrained.
+- Temporal later: Temporal adds infra and learning overhead; we retain a clean migration path via our seams.
+
+## Temporal Future-proofing (explicit design hooks)
+- Stable identifiers: workflow_id (external), run_id (internal), step_id (per node execution)
+- Idempotency and replay: idempotency_key per step; steps designed to be side-effect free or compensable
+- Cancellation and heartbeats: cooperative cancellation; periodic heartbeats from long steps for health checks
+- State modeling: event-sourced or snapshot+event hybrid; compact "cursor" at each edge
+- Activity boundaries: tool invocations and LLM calls treated as activities with clear retry/backoff policies
+
+These choices map onto Temporal concepts (Workflow ID, Activities, Signals, Queries) if/when we migrate.
+
+## Observability and Ops
+- Tracing: OpenTelemetry across Go and Python with shared context; redact PII as needed
+- Logging: Structured logs with correlation IDs; prompt/response redaction
+- Metrics: Latency, cost, token usage, step retry counts, tool errors, completion rates
+- Testing: Contract tests at the RPC boundary; golden traces for key flows; ephemeral env tests in CI
+
+## Security and Compliance
+- Boundary hardening: sidecar runs with least privilege; network ACLs; resource limits
+- Data handling: PII flags in metadata; redaction at sources and in logs; encryption at rest/in transit
+- Multi-tenancy: tenant ID propagated end-to-end; no cross-tenant state leakage (row-level security where feasible)
+
+## Alternatives Considered
+- Go-only orchestration (langchaingo + custom state)
+  - Pros: monolingual; simpler ops
+  - Cons: slower to reliable graph semantics; reinvents mature features
+- Semantic Kernel / AutoGen / CrewAI
+  - Pros: quick starts
+  - Cons: weaker production graph semantics vs LangGraph; Python/TS; less aligned with our needs
+- Temporal from day one
+  - Pros: rock-solid durability
+  - Cons: infra and learning overhead now; can defer while keeping migration easy
+- Google Cloud Workflows (ADR 0002)
+  - Pros: minimal ops; native GCP integration
+  - Cons: insufficient for stateful agent graphs and rich checkpoint semantics; superseded by this ADR
+
+## Consequences
+- Positive: faster path to robust agentic behavior and checkpointing; clear seams reduce lock-in; migration path to Temporal preserved
+- Negative: polyglot ops (Go + Python) and CI/build complexity; need to maintain RPC contracts and versioning discipline
+
+## Implementation Outline (MVP)
+- Define v1 protobuf/JSON schemas for AgentClient and event stream (per ADR 0008)
+- Implement Go AgentClient and ToolServer (with strict JSON schema validation)
+- Implement Python LangGraph sidecar with:
+  - Planner node, tool-executing node(s), checkpointing in Postgres
+  - RPC adaptors to call Go tools and emit events
+  - OTEL instrumentation and structured logging
+- Wire tracing/metrics/logging end-to-end
+- Add contract tests and a golden-path E2E in CI
+
+## Acceptance Criteria
+- Start/stream/cancel/resume flows work end-to-end with correlated traces
+- Checkpoints persist; runs are resumable after process restarts
+- Tool calls are idempotent and time-bounded
+- Dashboards show latency, cost, and error breakdown per step
+- No cross-tenant leakage in queries or logs
+
+## Rollback Plan
+- If the sidecar proves too costly/complex, replace with a minimal Go orchestrator behind the same AgentClient interface. RPC contracts remain stable.
+
+## Open Questions
+- Which vector store for MVP (pgvector vs Qdrant) and which Go client libraries?
+- Hosting model for the sidecar (Bazel-built container vs rules_python vs managed runtime)?
+- Do we need LangSmith or stick to OTEL + our own dashboards?
+

--- a/scripts/dev_matrix.sh
+++ b/scripts/dev_matrix.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs smoke tests in a small matrix of PUBSUB_ENABLED states.
+# Assumes dev_up.sh is already running services locally.
+
+API_PORT="${API_PORT:-8080}"
+
+run_case() {
+  local name="$1"; shift
+  echo "\n=== Matrix case: $name ==="
+  PUBSUB_ENABLED="$1" ./scripts/dev_smoke.sh || true
+}
+
+run_case "NOP publisher" ""
+run_case "Pub/Sub publisher" "true"
+
+echo "\nMatrix complete."
+

--- a/scripts/dev_matrix.sh
+++ b/scripts/dev_matrix.sh
@@ -8,12 +8,14 @@ API_PORT="${API_PORT:-8080}"
 
 run_case() {
   local name="$1"; shift
-  echo "\n=== Matrix case: $name ==="
+  echo ""
+  echo "=== Matrix case: $name ==="
   PUBSUB_ENABLED="$1" ./scripts/dev_smoke.sh || true
 }
 
 run_case "NOP publisher" ""
 run_case "Pub/Sub publisher" "true"
 
-echo "\nMatrix complete."
+echo ""
+echo "Matrix complete."
 

--- a/scripts/dev_smoke.sh
+++ b/scripts/dev_smoke.sh
@@ -41,7 +41,7 @@ http_check() {
 # API health
 http_check "API health" GET "http://localhost:${API_PORT}/healthz"
 
-# Baton IssueDirective (expect 200)
+# Baton IssueDirective (expect 200) — echoes which publisher is selected via API logs
 http_check "Baton IssueDirective" POST "http://localhost:${API_PORT}/libretto.baton.v1.BatonService/IssueDirective" '{"text":"Introduce a betrayal","act":"2","target":"protagonist"}'
 
 # Plot Weaver stub (expect 200)

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -63,7 +63,7 @@ echo "- API:          http://localhost:${API_PORT}"
 echo "- Plot Weaver:  http://localhost:${PLOT_PORT}"
 echo "- GraphWrite:   http://localhost:${GRAPHWRITE_PORT}"
 
-echo "\nTip: In a new terminal, run ./scripts/dev_smoke.sh to smoke test endpoints."
+echo "\nTip: In a new terminal, run ./scripts/dev_smoke.sh or ./scripts/dev_matrix.sh (matrix runs both NOP and PUBSUB_ENABLED=true)"
 
 echo "\nPress Ctrl+C to stop..."
 

--- a/services/agents/plotweaver/main.go
+++ b/services/agents/plotweaver/main.go
@@ -8,6 +8,7 @@ import (
 
 func main() {
 	http.HandleFunc("/", handler)
+	http.HandleFunc("/push", pushHandler)
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))

--- a/services/api/BUILD.bazel
+++ b/services/api/BUILD.bazel
@@ -4,7 +4,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "publisher",
-    srcs = ["publisher/publisher.go"],
+    srcs = [
+        "publisher/publisher.go",
+        "publisher/pubsub.go",
+        "publisher/selector.go",
+    ],
     importpath = "github.com/barrynorthern/libretto/services/api/publisher",
     visibility = ["//visibility:public"],
 )

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -37,7 +37,14 @@ func main() {
 	}
 
 	mux := healthMux()
-	pub := publisher.NopPublisher{}
+	pub := publisher.Select()
+	// Log which publisher we selected for visibility during manual tests
+	switch pub.(type) {
+	case publisher.PubSubPublisher:
+		log.Printf("publisher=pubsub topic=%s", topic)
+	default:
+		log.Printf("publisher=nop topic=%s", topic)
+	}
 	svc := &apiserver.BatonServer{Pub: pub, Topic: topic, Producer: producer}
 	mux.Handle(batonv1connect.NewBatonServiceHandler(svc))
 

--- a/services/api/publisher/pubsub.go
+++ b/services/api/publisher/pubsub.go
@@ -1,0 +1,16 @@
+package publisher
+
+import (
+	"context"
+	"fmt"
+)
+
+// PubSubPublisher is a placeholder for a real Pub/Sub implementation.
+// For now, it just logs distinctively to differentiate from NOP.
+type PubSubPublisher struct{}
+
+func (PubSubPublisher) Publish(ctx context.Context, topic string, data []byte) error {
+	fmt.Printf("[pubsub] publish to %s: %d bytes\n", topic, len(data))
+	return nil
+}
+

--- a/services/api/publisher/selector.go
+++ b/services/api/publisher/selector.go
@@ -1,0 +1,20 @@
+package publisher
+
+import (
+	"context"
+	"os"
+)
+
+// Select returns a Publisher based on env: if PUBSUB_ENABLED=true, returns PubSubPublisher; else NopPublisher.
+func Select() Publisher {
+	if os.Getenv("PUBSUB_ENABLED") == "true" {
+		return PubSubPublisher{}
+	}
+	return NopPublisher{}
+}
+
+// Smoke publishes a small payload to verify the publisher wiring.
+func Smoke(ctx context.Context, p Publisher) error {
+	return p.Publish(ctx, "libretto.dev.smoke", []byte("ok"))
+}
+

--- a/services/api/publisher/selector_test.go
+++ b/services/api/publisher/selector_test.go
@@ -1,0 +1,41 @@
+package publisher
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+type capturePublisher struct{ called bool }
+
+func (c *capturePublisher) Publish(ctx context.Context, topic string, data []byte) error {
+	c.called = true
+	return nil
+}
+
+func TestSelectDefaultsToNop(t *testing.T) {
+	t.Setenv("PUBSUB_ENABLED", "")
+	p := Select()
+	if _, ok := p.(NopPublisher); !ok {
+		t.Fatalf("expected NopPublisher by default")
+	}
+}
+
+func TestSelectPubSubWhenEnabled(t *testing.T) {
+	t.Setenv("PUBSUB_ENABLED", "true")
+	p := Select()
+	if _, ok := p.(PubSubPublisher); !ok {
+		t.Fatalf("expected PubSubPublisher when PUBSUB_ENABLED=true")
+	}
+}
+
+func TestSmoke(t *testing.T) {
+	p := &capturePublisher{}
+	if err := Smoke(context.Background(), p); err != nil {
+		t.Fatalf("smoke err: %v", err)
+	}
+	if !p.called {
+		t.Fatalf("expected publish to be called")
+	}
+}
+

--- a/services/graphwrite/server/server_test.go
+++ b/services/graphwrite/server/server_test.go
@@ -8,7 +8,23 @@ import (
 	graphv1 "github.com/barrynorthern/libretto/gen/go/libretto/graph/v1"
 )
 
-type fakeStore struct{ version string; count int32; err error }
+func TestApplyRejectsEmptyDeltas(t *testing.T) {
+	s := &GraphWriteServer{Store: fakeStore{version: "01JF00", count: 0}}
+	req := connect.NewRequest(&graphv1.ApplyRequest{ParentVersionId: "01JROOT", Deltas: []*graphv1.Delta{}})
+	_, err := s.Apply(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error for empty deltas")
+	}
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("expected invalid argument, got %v", connect.CodeOf(err))
+	}
+}
+
+type fakeStore struct {
+	version string
+	count   int32
+	err     error
+}
 
 func (f fakeStore) Apply(parent string, deltas []*graphv1.Delta) (string, int32, error) {
 	return f.version, f.count, f.err
@@ -28,4 +44,3 @@ func TestApplySuccess(t *testing.T) {
 		t.Fatalf("applied got %d want %d", got, want)
 	}
 }
-


### PR DESCRIPTION
# Problem statement
- We need single-command workflows for running and validating the stack, avoiding manual curl sequences.
- API needs an env-gated publisher switch to exercise both NOP and Pub/Sub paths during development.
- Plot Weaver needs a push-compatible endpoint to accept Pub/Sub push payloads.
- GraphWrite should reject empty delta batches to keep the contract meaningful.
- ADR 0009 sets orchestration seams; these changes keep boundaries tight without coupling to orchestration internals.

# Solution overview
- API: Env-gated publisher selection with visibility logs
  - PUBSUB_ENABLED=true selects PubSubPublisher (placeholder), else NopPublisher
  - Logs publisher=pubsub|nop with topic for clarity
- Agents: Plot Weaver /push endpoint
  - Accepts GCP push JSON; base64 decodes message.data; logs attributes + decoded payload; returns 200
- GraphWrite: Apply validation
  - Returns InvalidArgument (HTTP 400 via Connect) when deltas=[]
  - Unit test added
- Developer workflow: Make-first UX
  - make dev-up: starts API, Plot Weaver, GraphWrite with readiness checks
  - make dev-smoke: runs concise, colorized smoke tests with HTTP status/body on failures
  - make matrix: runs smoke in two modes (NOP and PUBSUB_ENABLED=true)

# Files changed (high-level)
- services/api
  - main.go: env-gated publisher selection + log
  - publisher/pubsub.go: placeholder Pub/Sub publisher
  - publisher/selector.go + selector_test.go
  - BUILD.bazel: updated sources
- services/agents/plotweaver
  - main.go: register /push
  - handler.go: pushHandler parsing Pub/Sub push JSON
- services/graphwrite/server
  - server.go: empty deltas → InvalidArgument
  - server_test.go: TestApplyRejectsEmptyDeltas
- scripts (implementation detail invoked by Make)
  - dev_up.sh: readiness checks; matrix tip
  - dev_smoke.sh: colorized pass/fail with status/body on failure
  - dev_matrix.sh: runs smoke in NOP and PUBSUB modes
- Makefile
  - build, test, dev-up, dev-smoke, matrix, dev-down
- docs/adr
  - 0009-agent-orchestration-seams-and-langgraph-sidecar.md (Accepted)

# How to verify 
- Start the stack:
  - `make dev-up`
- Run smoke:
  - `make dev-smoke`
- Run both publisher modes:
  - `make matrix`
- API logs will show which publisher is active per run (publisher=nop|pubsub)

# Acceptance criteria (ticket 00002)
- Env-gated publisher selection [met]
- Plot Weaver accepts Pub/Sub push JSON; decodes payload [met]
- GraphWrite rejects empty deltas with 400 [met]
- Tests added/green [met]
- Make-first dev workflow and matrix verification [met]

# Out of scope (deferred)
- Real Pub/Sub client wiring and credentials
- Schema validation for envelopes/deltas
- Firestore persistence
- Orchestration wiring per ADR 0009 (future AgentClient RPC contracts)

# Risks and mitigations
- Confusing placeholder Pub/Sub for real publishing
  - Mitigation: explicit log line and Make-based matrix that contrasts modes
- Logging raw payload in dev
  - Mitigation: later add schema validation and redaction; document prod logging rules

# Related
- ADR 0009: Agent Orchestration Strategy — API Seams + LangGraph sidecar

# Changelog
- API: env-gated publisher selection with logs
- Agents: Plot Weaver /push for Pub/Sub push format
- GraphWrite: empty deltas rejected; tests added
- DX: Make-based dev-up, dev-smoke, matrix; readiness checks
- Docs: README updated to prefer Make; ADR 0009 added