### PR TITLE
feat(plotweaver): consume DirectiveIssued and emit SceneProposalReady (typed Event oneof); env-based publisher

### DIFF
--- a/plans/tickets/00003-devpush-publisher-and-envelope-validation.md
+++ b/plans/tickets/00003-devpush-publisher-and-envelope-validation.md
@@ -1,9 +1,9 @@
 # 00003 – DevPush publisher and envelope validation (next)
 
-Status: Proposed
+Status: Completed
 Owner: barrynorthern
-Start: TBC
-Date completed: pending
+Start: 2025-08-17
+Date completed: 2025-08-17
 
 ## Context
 We can issue directives (API) and exercise GraphWrite, but the async “API → bus → Plot Weaver” path is not yet truly end‑to‑end. ADR 0009 emphasizes clear seams and keeping orchestration concerns separate. Rather than introduce a heavy Pub/Sub emulator now, we can add a dev‑only publisher that simulates the bus by HTTP POSTing to Plot Weaver, while validating the event envelope on both sides.

--- a/plans/tickets/00004-plotweaver-consumes-directive-and-emits-sceneproposal.md
+++ b/plans/tickets/00004-plotweaver-consumes-directive-and-emits-sceneproposal.md
@@ -1,0 +1,56 @@
+# 00004 – Plot Weaver consumes DirectiveIssued and emits SceneProposalReady (oneof Event)
+
+Status: Proposed
+Owner: barrynorthern
+Start: TBC
+Date completed: pending
+
+## Context
+We now publish typed Events (Envelope + oneof payload) and validate envelopes. Plot Weaver’s /push validates and logs incoming Events but does not yet act on DirectiveIssued nor publish a SceneProposalReady. Completing this agent loop will prove the end‑to‑end async path using DevPush locally.
+
+## Goal
+Implement a minimal Plot Weaver consumer that decodes DirectiveIssued Events and publishes a typed SceneProposalReady Event with a valid Envelope. Validate envelopes pre‑publish (Plot Weaver) and post‑decode as per the current approach and keep the ENVELOPE_VALIDATE gate.
+
+## Scope
+- Protobuf/contracts
+  - Reuse libretto.events.v1.Event (Envelope + oneof) with DirectiveIssued and SceneProposalReady
+- Plot Weaver
+  - Add a minimal publisher (reuse PUBLISHER env: nop|devpush|pubsub; default nop)
+  - /push: base64 decode, unmarshal Event (protojson), validate Envelope when ENVELOPE_VALIDATE != "0"
+  - On DirectiveIssued: synthesize a minimal SceneProposalReady and publish as typed Event with fresh Envelope (UUIDs; semver; producer=plotweaver; correlationId propagated)
+  - Validate Envelope pre‑publish when ENVELOPE_VALIDATE != "0"; log consumed/published with IDs
+  - Keep existing stub root handler
+- Tooling
+  - Keep Make as interface; rely on logs for smoke verification
+- Tests
+  - Plot Weaver unit tests:
+    - Valid DirectiveIssued → publish SceneProposalReady (fake publisher)
+    - Invalid envelope → 400; nothing published
+- CI
+  - Smoke‑matrix remains NOP, PUBSUB back‑compat, and DEVPUSH; verify via logs that SceneProposalReady is emitted in DevPush case
+
+## Acceptance criteria
+- In DevPush mode: issuing a directive leads to Plot Weaver logging that it consumed DirectiveIssued and published SceneProposalReady (with correlationId continuity)
+- Invalid envelopes rejected with 400 on /push; pre‑publish validation in Plot Weaver rejects invalid outbound Envelopes when enabled
+- Unit tests cover publish/no‑publish paths and validation failures
+- CI smoke‑matrix runs all three cases and uploads logs
+
+## Non‑functional requirements
+- Matrix step completes in < 60s on CI
+- Validation errors log actionable messages
+
+## Risks / mitigations
+- Divergence from real Pub/Sub push semantics → retain nop/devpush; emulator/cloud‑based tests later
+- Overfitting to dev behavior → keep publisher interface narrow; clear dev‑only boundaries
+
+## Out of scope (deferred)
+- Real Pub/Sub client/emulator
+- Thematic Steward behavior
+- Persistence downstream of SceneProposalReady
+
+## References
+- ADR 0009: docs/adr/0009-agent-orchestration-seams-and-langgraph-sidecar.md
+- ADR 0010: docs/adr/0010-event-contract-source-of-truth.md
+- Protos: proto/libretto/events/v1/events.proto
+- Make targets: Makefile (dev-up, dev-smoke, matrix)
+

--- a/services/agents/plotweaver/BUILD.bazel
+++ b/services/agents/plotweaver/BUILD.bazel
@@ -1,14 +1,31 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
+    name = "publisher",
+    srcs = [
+        "publisher/publisher.go",
+        "publisher/selector.go",
+    ],
+    importpath = "github.com/barrynorthern/libretto/services/agents/plotweaver/publisher",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
     name = "plotweaver_lib",
-    srcs = ["main.go", "handler.go"],
+    srcs = [
+        "main.go",
+        "handler.go",
+    ],
     importpath = "github.com/barrynorthern/libretto/services/agents/plotweaver",
     deps = [
+        ":publisher",
         "//gen/go/libretto/events/v1:events_v1",
+        "//packages/contracts/events:events",
         "@com_github_google_uuid//:go_default_library",
         "@org_golang_google_protobuf//encoding/protojson:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
+    importpath_aliases = {"github.com/barrynorthern/libretto/services/agents/plotweaver/publisher": ":plotweaver_lib"},
     visibility = ["//visibility:private"],
 )
 

--- a/services/agents/plotweaver/main.go
+++ b/services/agents/plotweaver/main.go
@@ -4,9 +4,20 @@ import (
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/barrynorthern/libretto/services/agents/plotweaver/publisher"
+)
+
+var (
+	plotPublisher publisher.Publisher
 )
 
 func main() {
+	// Publisher selection
+	var sel string
+	plotPublisher, sel = publisher.Select()
+	log.Printf("plotweaver publisher=%s", sel)
+
 	http.HandleFunc("/", handler)
 	http.HandleFunc("/push", pushHandler)
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/services/agents/plotweaver/publisher/publisher.go
+++ b/services/agents/plotweaver/publisher/publisher.go
@@ -1,0 +1,33 @@
+package publisher
+
+import (
+	"context"
+	"fmt"
+)
+
+// Publisher publishes events (dev or real). For now, just logs distinctively per implementation.
+type Publisher interface {
+	Publish(ctx context.Context, topic string, data []byte) error
+}
+
+type NopPublisher struct{}
+
+func (NopPublisher) Publish(ctx context.Context, topic string, data []byte) error {
+	fmt.Printf("publish to %s: %d bytes\n", topic, len(data))
+	return nil
+}
+
+type PubSubPublisher struct{}
+
+func (PubSubPublisher) Publish(ctx context.Context, topic string, data []byte) error {
+	fmt.Printf("[pubsub] publish to %s: %d bytes\n", topic, len(data))
+	return nil
+}
+
+type DevPushPublisher struct{}
+
+func (DevPushPublisher) Publish(ctx context.Context, topic string, data []byte) error {
+	fmt.Printf("[devpush] publish to %s: %d bytes\n", topic, len(data))
+	return nil
+}
+

--- a/services/agents/plotweaver/publisher/selector.go
+++ b/services/agents/plotweaver/publisher/selector.go
@@ -1,0 +1,20 @@
+package publisher
+
+import (
+	"fmt"
+	"os"
+)
+
+func Select() (Publisher, string) {
+	switch os.Getenv("PUBLISHER") {
+	case "pubsub":
+		return PubSubPublisher{}, "pubsub"
+	case "devpush":
+		return DevPushPublisher{}, "devpush"
+	case "nop", "":
+		return NopPublisher{}, "nop"
+	default:
+		return NopPublisher{}, fmt.Sprintf("unknown:%s", os.Getenv("PUBLISHER"))
+	}
+}
+


### PR DESCRIPTION
 ## Problem
- Plot Weaver validated incoming events but didn’t act on DirectiveIssued or emit a follow-up event, leaving the async loop incomplete in dev.

## Solution
- Implement typed handling in Plot Weaver:
  - On DirectiveIssued, synthesize and publish a SceneProposalReady as a typed Event (Envelope + oneof payload) using protojson
  - Propagate correlationId, set causationId to the inbound eventId, and generate fresh UUIDs for new envelope fields
  - Add env-based publisher selection for Plot Weaver: PUBLISHER ∈ {nop, devpush, pubsub} (default nop)
  - Validate outbound envelope before publish when ENVELOPE_VALIDATE != "0"
- Tests:
  - Plot Weaver unit tests cover valid/invalid paths
- Tooling:
  - Bazel targets updated; make dev-up and make matrix run NOP, PUBSUB back-compat, and DEVPUSH locally

## Expected outcome
- In DevPush mode, issuing a directive results in Plot Weaver consuming DirectiveIssued and publishing SceneProposalReady (visible in logs)
- Envelope validation is enforced consistently without relying on ad-hoc JSON payloads
