### PR TITLE
chore(docs+plans): add remaining vertical slice tickets and docs

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,0 +1,28 @@
+# Libretto User Guide
+
+Welcome to Libretto. This guide helps you get started with the developer MVP: running the services locally, issuing a directive, and seeing agents respond.
+
+## Quick start
+1. Prerequisites: Go 1.22+, Make, Docker (for emulators, optional initially).
+2. Clone and enter the repo.
+3. Run the stack:
+   - `make dev-up`
+4. Issue a directive (replace text as desired):
+   - `make dev-smoke`
+5. Inspect logs for the agent flow and responses.
+
+## Concepts (brief)
+- Baton: issues directives from API.
+- Event bus seam: DevPush simulates Pub/Sub locally.
+- Plot Weaver: consumes DirectiveIssued and emits SceneProposalReady.
+- GraphWrite: accepts deltas to persist narrative graph (emulator-backed in future steps).
+
+## Next steps
+- See plans/tickets for upcoming staircase steps toward the full vertical slice.
+- Once Firestore emulator is enabled, you’ll be able to view persisted scenes via a minimal UI.
+
+## Troubleshooting
+- Port conflicts: API 8080, Plot Weaver 8081, GraphWrite 8082.
+- Publisher selection: set `PUBLISHER=nop|devpush|pubsub`.
+- Envelope validation: `ENVELOPE_VALIDATE=1` (default on); set to `0` to bypass during debugging.
+

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,30 @@
+# Getting Started
+
+This walkthrough shows how to run Libretto locally and exercise the current event-driven flow.
+
+## Install prerequisites
+- Go 1.22+
+- Make
+- Docker (for emulators in later steps)
+
+## Run the services
+- `make dev-up`
+  - Starts API (8080), Plot Weaver (8081), GraphWrite (8082)
+  - Select publisher via env: `PUBLISHER=nop|devpush|pubsub` (default nop)
+
+## Issue a directive
+- `make dev-smoke`
+  - In DevPush mode, the API publishes a DirectiveIssued; Plot Weaver consumes it and emits SceneProposalReady.
+
+## Verify behavior
+- Look for logs like:
+  - "plotweaver: consumed=DirectiveIssued published=SceneProposalReady correlationId=..."
+  - "plotweaver publisher=devpush|nop|pubsub"
+
+## What’s next
+- Persistence: GraphWrite to Firestore emulator
+- Minimal UI: Canvas/Inspector reads scenes
+
+## Troubleshooting
+- If `go test ./...` fails, see bug ticket 00005-bug for known issues to resolve in a separate branch.
+

--- a/plans/tickets/00005-bug-fix-api-tests-green.md
+++ b/plans/tickets/00005-bug-fix-api-tests-green.md
@@ -1,0 +1,44 @@
+# 00005-bug – Fix API tests to green (compilation errors)
+
+Status: Proposed
+Owner: barrynorthern
+Start: TBC
+Date completed: pending
+
+## Context
+Running `go test ./...` shows API test failures unrelated to 00004 plotweaver work. These prevent a clean CI signal and should be addressed in their own branch/PR before proceeding with new feature work.
+
+Observed errors:
+- services/api/publisher/selector_test.go: unused import "os"
+- services/api/server/baton_server_negative_test.go: handler return signature mismatch; connect-go now returns 2 values
+- services/api/server/baton_server_negative_test.go: Attempt to call `MarshalJSON` on connect.Request which doesn't exist
+
+## Goal
+Restore a green test suite by fixing compilation errors in the API tests.
+
+## Scope
+- services/api/publisher/selector_test.go
+  - Remove unused import(s) and ensure test compiles and asserts selector behavior.
+- services/api/server/baton_server_negative_test.go
+  - Update to current connect-go handler construction signature (capture both handler and path when needed)
+  - Replace invalid `MarshalJSON` usage with proper request building using httptest and JSON body, or connect-go client request types
+  - Keep the negative behavior under test intact, adapting to current server surface
+- No production code changes unless strictly required to make tests compile; prefer amending tests.
+
+## Acceptance criteria
+- `go test ./...` passes locally
+- CI shows green for API packages
+
+## Non-functional notes
+- Keep diffs small and focused; no dependency updates
+
+## Out of scope
+- Feature changes to API handlers beyond what's necessary for tests
+- Broader refactors of publisher selection
+
+## References
+- Connect-Go docs: https://connect.build/docs/go/
+- Current failing files:
+  - services/api/publisher/selector_test.go
+  - services/api/server/baton_server_negative_test.go
+

--- a/plans/tickets/00006-graphwrite-apply-from-sceneproposalready.md
+++ b/plans/tickets/00006-graphwrite-apply-from-sceneproposalready.md
@@ -1,0 +1,57 @@
+# 00006 – Consume SceneProposalReady → GraphWrite.Apply (persistence step 1)
+
+Status: Proposed
+Owner: barrynorthern
+Start: TBC
+Date completed: pending
+
+## Context
+We now have Plot Weaver consuming DirectiveIssued and emitting a typed SceneProposalReady. To complete the MVP vertical slice, we need to persist a Scene node via GraphWrite when a SceneProposalReady arrives, proving the bus→agent→GraphWrite path. We'll do this with a minimal consumer that translates SceneProposalReady into one or more GraphWrite deltas and calls GraphWrite.Apply.
+
+## Goal
+Implement a minimal consumer for SceneProposalReady that constructs a GraphWrite ApplyRequest to create a Scene, then invokes GraphWrite.Apply using the existing connect-go client. Keep this local-only (DevPush/NOP) without real Pub/Sub yet.
+
+## Scope
+- Contracts
+  - Reuse libretto.events.v1.Event (Envelope + oneof) and SceneProposalReady payload
+  - No schema changes in this ticket
+- New service: Narrative Ingest (temporary name) or extend Plot Weaver for MVP
+  - Option A (preferred): Add a tiny agent service `narrative-ingest` with `/push` that listens for SceneProposalReady and calls GraphWrite
+  - Option B: Temporarily add the consumer to Plot Weaver to shorten the path; extract later
+- Consumer behavior
+  - Base64 decode and protojson unmarshal Event
+  - On SceneProposalReady, build a GraphWrite ApplyRequest with a single Delta:
+    - op: "create"
+    - entity_type: "Scene"
+    - entity_id: scene_id from event
+    - fields: { "title": title, "summary": summary }
+  - Call GraphWrite.Apply via connect-go client to http://localhost:${GRAPHWRITE_PORT:-8082}
+  - Log correlationId, causationId, graphVersionId returned
+- Configuration
+  - GRAPHWRITE_URL env (default http://localhost:8082)
+- Tests
+  - Unit test: valid SceneProposalReady → client.Apply called with expected request
+  - Unit test: invalid payload → 400; no Apply call
+- Tooling/CI
+  - Extend make matrix/dev smoke to exercise the flow end-to-end locally (DevPush)
+
+## Acceptance criteria
+- Running dev smoke with a DirectiveIssued results in:
+  - Plot Weaver consumes and emits SceneProposalReady
+  - Narrative Ingest (or Plot Weaver extended) consumes SceneProposalReady and calls GraphWrite.Apply
+  - Logs show correlationId continuity and a non-empty graphVersionId in response
+- Unit tests cover apply/no-apply paths and validation failures
+
+## Non-functional requirements
+- Keep < 60s matrix run time
+- Clear logs for tracing correlationId/causationId
+
+## Risks / mitigations
+- Service sprawl: start with Option B (extend Plot Weaver) if needed, extract to `narrative-ingest` in a follow-up
+- Schema leakage: keep the mapper from event → deltas isolated in a small function with tests
+
+## Out of scope (deferred)
+- Real Pub/Sub client/emulator
+- Firestore persistence implementation (GraphWrite remains in-memory)
+- Thematic Steward participation
+

--- a/plans/tickets/00007-graphwrite-firestore-emulator-persistence.md
+++ b/plans/tickets/00007-graphwrite-firestore-emulator-persistence.md
@@ -1,0 +1,42 @@
+# 00007 – GraphWrite persistence via Firestore emulator (persistence step 2)
+
+Status: Proposed
+Owner: barrynorthern
+Start: TBC
+Date completed: pending
+
+## Context
+We have an in-memory GraphWrite server and a plan to call Apply from a consumer of SceneProposalReady. To move closer to the true vertical slice, we need GraphWrite to persist deltas into a Firestore emulator with a minimal schema.
+
+## Goal
+Implement Firestore emulator-backed persistence for GraphWrite.Apply, mapping incoming Deltas into documents.
+
+## Scope
+- Infra/Tooling
+  - Add Firestore emulator to dev stack (Make: start/stop)
+  - Configure emulator env for GraphWrite (`FIRESTORE_EMULATOR_HOST`, project)
+- GraphWrite service
+  - Add a Firestore-backed Store implementation alongside InMemoryStore
+  - Map Delta(op=create, entity_type=Scene) to collection `nodes_scene` with fields {title, summary}
+  - Return a new graph_version_id (e.g., ULID or UUID) and applied count
+- Tests
+  - Unit test mapping function(s)
+  - Integration-style test behind an env flag to run against emulator locally
+
+## Acceptance criteria
+- `make dev-up` starts emulator and GraphWrite uses it when configured
+- Apply requests with a Scene create delta persist a document to nodes_scene
+- Logs include graph_version_id and applied count
+
+## Non-functional requirements
+- Keep emulator boot + test under a minute on CI
+- No production credentials required; emulator only
+
+## Out of scope
+- Adjacency indexes, edges, or multi-entity transactions
+- Security rules beyond minimal local defaults
+
+## References
+- Google Firestore emulator docs
+- proto/libretto/graph/v1/graphwrite.proto
+

--- a/plans/tickets/00008-canvas-inspector-minimal-read-from-firestore.md
+++ b/plans/tickets/00008-canvas-inspector-minimal-read-from-firestore.md
@@ -1,0 +1,35 @@
+# 00008 – Canvas/Inspector minimal read from Firestore (vertical slice UI)
+
+Status: Proposed
+Owner: barrynorthern
+Start: TBC
+Date completed: pending
+
+## Context
+With GraphWrite persisting scenes to Firestore emulator, we can complete the vertical slice by adding a minimal UI that reads and displays scenes.
+
+## Goal
+Provide a basic UI page that lists scenes and shows a detail view sourced from Firestore emulator.
+
+## Scope
+- UI
+  - Minimal page using existing stack (confirm tech; prefer Go or server-rendered where feasible; keep JS thin)
+  - Endpoint(s) to read from Firestore emulator and render list + detail
+  - Display title and summary for scenes
+- Tests
+  - Basic integration test: request page, contains scene title from emulator fixture
+- Tooling
+  - Make target to seed emulator with a scene document for local dev when needed
+
+## Acceptance criteria
+- Running the dev stack allows visiting a page that lists scenes stored via GraphWrite
+- Selecting a scene shows title and summary
+- Tests pass locally and in CI (using emulator)
+
+## Non-functional requirements
+- Keep load time snappy; minimal JS
+
+## Out of scope
+- Styling beyond bare minimum
+- Complex navigation or editing
+


### PR DESCRIPTION
Added tickets:
- plans/tickets/00005-bug-fix-api-tests-green.md
- plans/tickets/00006-graphwrite-apply-from-sceneproposalready.md
- plans/tickets/00007-graphwrite-firestore-emulator-persistence.md
- plans/tickets/00008-canvas-inspector-minimal-read-from-firestore.md

Seeded user docs:
- docs/guide/README.md
- docs/guide/getting-started.md