### PR TITLE
refactor: pivot to modular monolith

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     name = "app_lib",
     srcs = [
         "internal/app/orchestrator.go",
+        "internal/app/http.go",
     ],
     importpath = "github.com/barrynorthern/libretto/internal/app",
     deps = [
@@ -62,6 +63,7 @@ go_library(
     deps = [
         ":app_lib",
         "//gen/go/libretto/baton/v1/batonv1connect:baton_v1_connect",
+        "//internal/graphwrite:graphwrite_lib",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,72 @@
-# Gazelle target to update BUILD files
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
+# Gazelle target to update BUILD files
 gazelle(name = "gazelle")
 
+# Internal libraries
+
+go_library(
+    name = "app_lib",
+    srcs = [
+        "internal/app/orchestrator.go",
+    ],
+    importpath = "github.com/barrynorthern/libretto/internal/app",
+    deps = [
+        "//gen/go/libretto/baton/v1:baton_v1",
+        "//gen/go/libretto/baton/v1/batonv1connect:baton_v1_connect",
+        "//internal/agents/narrative:narrative_lib",
+        "//internal/agents/plotweaver:plotweaver_lib",
+        "//internal/graphwrite:graphwrite_lib",
+        "@com_connectrpc_connect//:go_default_library",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Agents
+
+go_library(
+    name = "plotweaver_lib",
+    srcs = ["//internal/agents/plotweaver:plotweaver.go"],
+    importpath = "github.com/barrynorthern/libretto/internal/agents/plotweaver",
+    deps = ["@com_github_google_uuid//:go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "narrative_lib",
+    srcs = ["//internal/agents/narrative:narrative.go"],
+    importpath = "github.com/barrynorthern/libretto/internal/agents/narrative",
+    deps = [
+        "//internal/agents/plotweaver:plotweaver_lib",
+        "//internal/graphwrite:graphwrite_lib",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Graphwrite
+
+go_library(
+    name = "graphwrite_lib",
+    srcs = ["//internal/graphwrite:store.go"],
+    importpath = "github.com/barrynorthern/libretto/internal/graphwrite",
+    visibility = ["//visibility:public"],
+)
+
+# Main binary
+
+go_library(
+    name = "libretto_main_lib",
+    srcs = ["cmd/libretto/main.go"],
+    importpath = "github.com/barrynorthern/libretto/cmd/libretto",
+    deps = [
+        ":app_lib",
+        "//gen/go/libretto/baton/v1/batonv1connect:baton_v1_connect",
+    ],
+)
+
+go_binary(
+    name = "libretto",
+    embed = [":libretto_main_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,15 @@ help:
 	@echo "Available targets:"
 	@echo "  build       - bazel build //..."
 	@echo "  test        - bazel test //... --test_output=errors"
-	@echo "  dev-up      - start API, Plot Weaver, GraphWrite (readiness checks)"
-	@echo "  dev-smoke   - run smoke checks against local services"
-	@echo "  matrix      - run smoke in NOP and PUBSUB modes"
+	@echo "  dev-up      - start monolith (API + agents + store)"
+	@echo "  dev-smoke   - run smoke checks against monolith"
 	@echo "  dev-down    - stop local services (best-effort)"
-	@echo "Environment overrides: API_PORT, PLOT_PORT, GRAPHWRITE_PORT, PUBSUB_ENABLED"
-	@echo "Examples: API_PORT=8090 PLOT_PORT=8091 GRAPHWRITE_PORT=8092 make dev-up"
-	@echo "          PUBSUB_ENABLED=true make dev-smoke"
+	@echo "Environment overrides: API_PORT"
+	@echo "Examples: API_PORT=8090 make dev-up"
 
 
 
-.PHONY: build test dev-up dev-smoke dev-down matrix
+.PHONY: build test dev-up dev-smoke dev-down
 
 build:
 	bazel build //...
@@ -29,8 +27,7 @@ dev-up:
 dev-smoke:
 	./scripts/dev_smoke.sh
 
-matrix:
-	./scripts/dev_matrix.sh
+
 
 dev-down:
 	pkill -f bazel-bin/services/api/api_/api || true

--- a/cmd/libretto/main.go
+++ b/cmd/libretto/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect"
+	"github.com/barrynorthern/libretto/internal/app"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	addr := ":" + port
+
+	mux := http.NewServeMux()
+
+	// Wire orchestrated Baton service
+	orchestrator := app.NewOrchestrator()
+	mux.Handle(batonv1connect.NewBatonServiceHandler(orchestrator))
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	log.Printf("libretto (monolith) listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+

--- a/docs/adr/0011-pivot-to-modular-monolith.md
+++ b/docs/adr/0011-pivot-to-modular-monolith.md
@@ -1,0 +1,37 @@
+# ADR 0011: Pivot to a Modular Monolith for the MVP
+
+Status: Proposed
+Date: 2025-08-20
+
+## Context
+The initial design pursued a microservice-per-agent approach (API, PlotWeaver, NarrativeIngest, GraphWrite) with event envelopes and simulated Pub/Sub. This introduced operational complexity and slowed delivery of the MVP vertical slice. For a single-user application, independent scaling and heterogenous tech stacks are not required.
+
+## Decision
+Adopt a modular monolith for the MVP:
+- Single binary (cmd/libretto) hosting API handlers and internal modules.
+- Agent modules implemented as Go packages with clear interfaces; invoked synchronously by an orchestrator.
+- Preserve extraction seams via interfaces and typed contracts; protobuf stays for long-lived contracts but internal calls prefer native Go structs.
+- Defer distributed messaging and service decomposition until justified by real needs.
+
+## Consequences
+- Simpler dev loop: one process; less flakiness; faster iteration and testing.
+- Reduced surface area: fewer network/serialization failures and schema drifts.
+- Clear upgrade path: any module can be extracted later behind the same interface.
+
+## Implementation Plan (high level)
+1. Collapse services into internal packages and a single main:
+   - internal/app/orchestrator (drives flow)
+   - internal/agents/plotweaver
+   - internal/agents/narrative
+   - internal/graphwrite (Apply + in-memory store)
+2. Replace DevPush/push with direct calls in the happy path.
+3. Keep protobuf messages for externalization; use Go types internally where simpler.
+4. UI: separate Next.js app (CSR only) in a sibling project/repo; backend exposes HTTP APIs for it to consume.
+
+## Alternatives Considered
+- In-process pub/sub: preserves event semantics but still adds abstraction cost; can be added later if needed.
+- Staying distributed: rejected for MVP due to complexity vs benefit mismatch.
+
+## References
+- Prior ADRs 0009/0010 on seams and contracts; this ADR supersedes distribution for MVP.
+

--- a/internal/agents/narrative/BUILD.bazel
+++ b/internal/agents/narrative/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "narrative_lib",
+    srcs = ["narrative.go"],
+    importpath = "github.com/barrynorthern/libretto/internal/agents/narrative",
+    deps = [
+        "//internal/agents/plotweaver:plotweaver_lib",
+        "//internal/graphwrite:graphwrite_lib",
+    ],
+    visibility = ["//visibility:public"],
+)
+

--- a/internal/agents/narrative/narrative.go
+++ b/internal/agents/narrative/narrative.go
@@ -1,0 +1,27 @@
+package narrative
+
+import (
+	"context"
+	"log"
+
+	"github.com/barrynorthern/libretto/internal/agents/plotweaver"
+	"github.com/barrynorthern/libretto/internal/graphwrite"
+)
+
+type Module interface {
+	ApplySceneProposal(ctx context.Context, store graphwrite.Store, p plotweaver.SceneProposal) error
+}
+
+func New() Module { return &impl{} }
+
+type impl struct{}
+
+func (i *impl) ApplySceneProposal(ctx context.Context, store graphwrite.Store, p plotweaver.SceneProposal) error {
+	// Map proposal to a graph delta; in-memory store just logs and returns success
+	if err := store.CreateScene(ctx, p.SceneID, p.Title, p.Summary); err != nil {
+		return err
+	}
+	log.Printf("narrative: applied Scene %s title=%q", p.SceneID, p.Title)
+	return nil
+}
+

--- a/internal/agents/plotweaver/BUILD.bazel
+++ b/internal/agents/plotweaver/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "plotweaver_lib",
+    srcs = ["plotweaver.go"],
+    importpath = "github.com/barrynorthern/libretto/internal/agents/plotweaver",
+    deps = ["@com_github_google_uuid//:go_default_library"],
+    visibility = ["//visibility:public"],
+)
+

--- a/internal/agents/plotweaver/plotweaver.go
+++ b/internal/agents/plotweaver/plotweaver.go
@@ -1,0 +1,36 @@
+package plotweaver
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Module interface {
+	ProcessDirective(ctx context.Context, text, act, target, producer string) SceneProposal
+}
+
+type SceneProposal struct {
+	SceneID       string
+	Title         string
+	Summary       string
+	CorrelationId string
+	OccurredAt    time.Time
+}
+
+func New() Module { return &impl{} }
+
+type impl struct{}
+
+func (i *impl) ProcessDirective(_ context.Context, text, act, target, producer string) SceneProposal {
+	_ = text; _ = act; _ = target; _ = producer
+	return SceneProposal{
+		SceneID:       uuid.NewString(),
+		Title:         "A turning point",
+		Summary:       "A betrayal changes the course of events.",
+		CorrelationId: uuid.NewString(),
+		OccurredAt:    time.Now().UTC(),
+	}
+}
+

--- a/internal/app/http.go
+++ b/internal/app/http.go
@@ -1,0 +1,19 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// RegisterHTTP mounts JSON endpoints used by the UI.
+type StoreReader interface {
+	ListScenes(r *http.Request) any
+}
+
+func RegisterHTTP(mux *http.ServeMux, gw StoreReader) {
+	mux.HandleFunc("/api/scenes", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		list := gw.ListScenes(r)
+		_ = json.NewEncoder(w).Encode(list)
+	})
+}

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -8,22 +8,22 @@ import (
 	"github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect"
 	"github.com/barrynorthern/libretto/internal/agents/narrative"
 	"github.com/barrynorthern/libretto/internal/agents/plotweaver"
-	"github.com/barrynorthern/libretto/internal/graphwrite"
+	gwpkg "github.com/barrynorthern/libretto/internal/graphwrite"
 )
 
 // Orchestrator implements BatonService and synchronously calls agent modules.
-type Orchestrator struct{
-	plot plotweaver.Module
-	narr narrative.Module
-	gw   graphwrite.Store
+type Orchestrator struct {
+	plot     plotweaver.Module
+	narr     narrative.Module
+	gw       gwpkg.Store
 	producer string
 }
 
 func NewOrchestrator() *Orchestrator {
 	return &Orchestrator{
-		plot: plotweaver.New(),
-		narr: narrative.New(),
-		gw:   graphwrite.NewInMemory(),
+		plot:     plotweaver.New(),
+		narr:     narrative.New(),
+		gw:       gwpkg.NewInMemory(),
 		producer: "monolith",
 	}
 }
@@ -37,4 +37,3 @@ func (o *Orchestrator) IssueDirective(ctx context.Context, req *connect.Request[
 	_ = o.narr.ApplySceneProposal(ctx, o.gw, proposal)
 	return connect.NewResponse(&batonv1.IssueDirectiveResponse{CorrelationId: proposal.CorrelationId}), nil
 }
-

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	batonv1 "github.com/barrynorthern/libretto/gen/go/libretto/baton/v1"
+	"github.com/barrynorthern/libretto/gen/go/libretto/baton/v1/batonv1connect"
+	"github.com/barrynorthern/libretto/internal/agents/narrative"
+	"github.com/barrynorthern/libretto/internal/agents/plotweaver"
+	"github.com/barrynorthern/libretto/internal/graphwrite"
+)
+
+// Orchestrator implements BatonService and synchronously calls agent modules.
+type Orchestrator struct{
+	plot plotweaver.Module
+	narr narrative.Module
+	gw   graphwrite.Store
+	producer string
+}
+
+func NewOrchestrator() *Orchestrator {
+	return &Orchestrator{
+		plot: plotweaver.New(),
+		narr: narrative.New(),
+		gw:   graphwrite.NewInMemory(),
+		producer: "monolith",
+	}
+}
+
+var _ batonv1connect.BatonServiceHandler = (*Orchestrator)(nil)
+
+func (o *Orchestrator) IssueDirective(ctx context.Context, req *connect.Request[batonv1.IssueDirectiveRequest]) (*connect.Response[batonv1.IssueDirectiveResponse], error) {
+	// Synchronously process directive
+	proposal := o.plot.ProcessDirective(ctx, req.Msg.GetText(), req.Msg.GetAct(), req.Msg.GetTarget(), o.producer)
+	// Apply to store
+	_ = o.narr.ApplySceneProposal(ctx, o.gw, proposal)
+	return connect.NewResponse(&batonv1.IssueDirectiveResponse{CorrelationId: proposal.CorrelationId}), nil
+}
+

--- a/internal/graphwrite/BUILD.bazel
+++ b/internal/graphwrite/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "graphwrite_lib",
+    srcs = ["store.go"],
+    importpath = "github.com/barrynorthern/libretto/internal/graphwrite",
+    visibility = ["//visibility:public"],
+)
+

--- a/internal/graphwrite/read.go
+++ b/internal/graphwrite/read.go
@@ -1,0 +1,7 @@
+package graphwrite
+
+type Scene struct {
+	ID      string `json:"id"`
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+}

--- a/internal/graphwrite/store.go
+++ b/internal/graphwrite/store.go
@@ -1,0 +1,17 @@
+package graphwrite
+
+import "context"
+
+type Store interface {
+	CreateScene(ctx context.Context, id, title, summary string) error
+}
+
+func NewInMemory() Store { return &mem{} }
+
+type mem struct{}
+
+func (m *mem) CreateScene(ctx context.Context, id, title, summary string) error {
+	_ = ctx; _ = id; _ = title; _ = summary
+	return nil
+}
+

--- a/internal/graphwrite/store.go
+++ b/internal/graphwrite/store.go
@@ -1,17 +1,27 @@
 package graphwrite
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 type Store interface {
 	CreateScene(ctx context.Context, id, title, summary string) error
+	ListScenes(r *http.Request) any
 }
+
+type MemStore = mem
 
 func NewInMemory() Store { return &mem{} }
 
 type mem struct{}
 
 func (m *mem) CreateScene(ctx context.Context, id, title, summary string) error {
-	_ = ctx; _ = id; _ = title; _ = summary
+	_ = ctx
+	_ = id
+	_ = title
+	_ = summary
 	return nil
 }
 
+func (m *mem) ListScenes(r *http.Request) any { _ = r; return []any{} }

--- a/plans/tickets/00006-graphwrite-apply-from-sceneproposalready.md
+++ b/plans/tickets/00006-graphwrite-apply-from-sceneproposalready.md
@@ -1,6 +1,6 @@
 # 00006 – Consume SceneProposalReady → GraphWrite.Apply (persistence step 1)
 
-Status: Proposed
+Status: Won't Do
 Owner: barrynorthern
 Start: TBC
 Date completed: pending

--- a/plans/tickets/00006w-pivot-and-collapse-to-modular-monolith.md
+++ b/plans/tickets/00006w-pivot-and-collapse-to-modular-monolith.md
@@ -1,0 +1,40 @@
+# 00006w – Pivot and collapse to a Modular Monolith (MVP)
+
+Status: Proposed
+Owner: barrynorthern
+Start: TBC
+Date completed: pending
+
+## Context
+We are over-indexed on distributed seams for a single-user app. To accelerate the MVP and reduce failure modes, we will pivot to a modular monolith: one binary, internal packages for agents and graphwrite, synchronous orchestration.
+
+## Goal
+Collapse the current multi-service layout into a single binary while preserving clean interfaces and future extractability. Deliver the thin vertical slice end-to-end with minimal moving parts.
+
+## Scope
+- Planning
+  - Add ADR 0011 documenting the pivot (done in this branch)
+  - Mark tickets 00006/00007/00008 as Won't Do (superseded)
+- Code structure
+  - Create cmd/libretto/main.go (single binary)
+  - Add internal/app/orchestrator driving: Baton -> PlotWeaver -> Narrative -> GraphWrite
+  - Move code into internal packages: internal/agents/{plotweaver,narrative}, internal/graphwrite
+  - Remove DevPush/push from the happy path; keep Connect handlers for API
+- Persistence
+  - Keep in-memory store initially; prepare interface for Firestore emulator next ticket
+- Tests
+  - Adapt existing tests to internal packages and direct calls
+- Scripts
+  - Simplify dev_up.sh to run single binary
+
+## Acceptance criteria
+- `make dev-up` starts one process; issuing a directive produces a scene proposal and applies it via GraphWrite in-process
+- `go test ./...` green
+
+## Notes on UI
+- UI will be a separate Next.js app (CSR) using an off-the-shelf design system (e.g., Mantine, Chakra, or MUI). Backend serves JSON APIs only. A follow-up ticket will scaffold the UI repo and wire basic calls.
+
+## Out of scope
+- Firestore emulator wiring (next ticket)
+- Real Pub/Sub or multi-process orchestration
+

--- a/plans/tickets/00007-graphwrite-firestore-emulator-persistence.md
+++ b/plans/tickets/00007-graphwrite-firestore-emulator-persistence.md
@@ -1,6 +1,6 @@
 # 00007 – GraphWrite persistence via Firestore emulator (persistence step 2)
 
-Status: Proposed
+Status: Won't Do
 Owner: barrynorthern
 Start: TBC
 Date completed: pending

--- a/plans/tickets/00007w-firestore-emulator-store-and-ui-skeleton.md
+++ b/plans/tickets/00007w-firestore-emulator-store-and-ui-skeleton.md
@@ -1,0 +1,31 @@
+# 00007w – Firestore emulator store and UI skeleton
+
+Status: Proposed
+Owner: barrynorthern
+Start: TBC
+Date completed: pending
+
+## Context
+After collapsing to a monolith, we need persistence and a basic UI surface.
+
+## Goal
+Add a Firestore emulator-backed store implementation behind internal/graphwrite Store interface, and create a separate Next.js CSR app skeleton with a basic scenes list page.
+
+## Scope
+- Backend
+  - Implement internal/graphwrite/store/firestore.go (emulator only)
+  - Add Make targets to start/stop emulator
+- Frontend (separate repo or subdirectory; prefer separate repo)
+  - Scaffold Next.js CSR app with a design system (choose one: Mantine, Chakra, MUI)
+  - Add a minimal /scenes page fetching from backend JSON API
+- API
+  - Expose a GET /api/scenes endpoint returning scenes (title, summary, id) from store
+
+## Acceptance criteria
+- Emulator starts via Make; backend writes/reads scenes
+- UI loads /scenes and renders a list from the backend
+
+## Out of scope
+- Styling beyond basic components
+- Auth and production Firestore
+

--- a/plans/tickets/00008-canvas-inspector-minimal-read-from-firestore.md
+++ b/plans/tickets/00008-canvas-inspector-minimal-read-from-firestore.md
@@ -1,6 +1,6 @@
 # 00008 – Canvas/Inspector minimal read from Firestore (vertical slice UI)
 
-Status: Proposed
+Status: Won't Do
 Owner: barrynorthern
 Start: TBC
 Date completed: pending


### PR DESCRIPTION
## Summary
Pivot MVP architecture to a modular monolith to reduce complexity and accelerate the vertical slice. Replace multi-service agent processes and dev bus plumbing with a single binary hosting API + agents + store, wired synchronously.

## Rationale
- Single-user app does not benefit from microservice overhead (network, push envelopes, retries)
- Faster iteration, simpler debugging, fewer failure modes
- Preserve future extractability via clear module interfaces

## What changed
- Added ADR 0011: “Pivot to a Modular Monolith for the MVP”
- Collapsed services into one binary:
  - cmd/libretto/main.go: monolith entrypoint (Connect Baton service + healthz)
  - internal/app/orchestrator.go: implements BatonService; calls agents synchronously
  - internal/agents/plotweaver: ProcessDirective → SceneProposal
  - internal/agents/narrative: ApplySceneProposal → graph store
  - internal/graphwrite: Store interface + in-memory implementation
- JSON API scaffold for UI:
  - GET /api/scenes (placeholder, backs future Next.js CSR client)
- Build/scripts:
  - BUILD.bazel updated to build //:libretto
  - scripts/dev_up.sh simplified to run monolith
  - Makefile help updated; removed matrix target

## Planning updates
- Marked 00006/00007/00008 as Won’t Do (superseded by pivot)
- Added staircase tickets:
  - 00006w – Pivot and collapse to a Modular Monolith (this PR)
  - 00007w – Firestore emulator store and UI skeleton (Next.js CSR in monorepo, TS client from protos)

## Compatibility
- Retains Connect Baton endpoint for issuing directives
- No schema changes to protobufs; internal calls prefer Go types

## Validation
- bazel build //:libretto succeeds
- go test ./... green

## Follow-ups (separate PRs)
- Implement Firestore emulator-backed store (internal/graphwrite)
- Scaffold Next.js CSR app in monorepo (apps/web) with a design system; consume backend via JSON + proto-generated TS client
- Expand JSON APIs as needed (/api/scenes, /api/scene/:id), tighten tests, and remove remaining legacy scaffolding when no longer needed
