### PR TITLE
docs(planning): strategy, tech guidelines, domain spec, tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 A multi-agent narrative orchestration engine where the user (the Conductor) directs specialized AI agents to build a Living Narrative graph. This is not a traditional writing app; prose is generated from the model and refined via structured controls.
 
-## Status
-- Specification: v1.1 (spec.md) — authoritative source of truth using EARS-style functional requirements
-- Planning: plans/execution-plan.md — phased plan, WBS, CI/CD outline, Firestore layout, SLOs
-- Schemas: JSON Schemas for events and entities under /schemas
+## Strategy & Stack
+- Product strategy: plans/libretto-product-strategy.md
+- Tech stack guidelines: plans/tech-stack-guidelines.md
 
 ## Core ideas
 - The Conductor, not the typist: high-level directives via a Baton (NL command palette)
@@ -13,51 +12,42 @@ A multi-agent narrative orchestration engine where the user (the Conductor) dire
 - Multi-agent AI: event-driven agents (Plot Weaver, Thematic Steward, etc.) collaborating over a Narrative Event Bus
 - Generated prose: prose is a read-only view generated from the model; refinements happen via Tuners or graph edits
 
-## MVP scope (high level)
-- Firestore as the canonical store with denormalized adjacency indexes (Graph Service owns all mutations)
-- Google Cloud Workflows for orchestration (Temporal-ready design)
-- Firebase Auth (RBAC: Owner/Editor/Viewer), WorkOS later if needed
-- Real-time: Firestore listeners as the source of truth; WebSockets for transient streaming only
-- Bootstrap: template-first wizard with lightweight paste/upload assist (Markdown/CSV/TXT)
-- Export: final copy (Markdown) and compendia (CSV/JSON/Markdown)
+## MVP at a glance
+- Desktop-first; no cloud infra required to use
+- SQLite persistence; sqlc repositories
+- Context Manager + RAG for narrative-aware prompts
+- Simple Baton flow: Directive → Proposal → Persisted Scene → UI list/detail
 
-## Architecture at a glance
-- UI: Next.js (planned) — Canvas, Inspector, Governor
-- Event bus: Cloud Pub/Sub with JSON-schema’d events (envelope + versioned payloads)
-- Agents: Cloud Functions/Run (starting simple) emitting/consuming events; strictly idempotent
-- Durable flows: Google Cloud Workflows for multi-step chains with checkpoints
-- RAG (later phases): Vertex AI Vector Search projection of the Living Narrative
+## Architecture (current)
+- Single process with internal modules: Orchestrator, PlotWeaver, Narrative, GraphWrite store, Context Manager
+- Wails React UI calls Go bindings; protobuf DTOs at the boundary; TS client generated via buf
 
 ## Repository layout
 ```
-/spec.md                    # Specification v1.1 (canonical)
-/plans/execution-plan.md    # Phases, WBS, CI/CD, SLOs
-/schemas/events/*.json      # Event envelope + MVP events
-/schemas/model/*.json       # Minimal entity schemas (MVP)
-/docs/graphwrite-api.md     # GraphWrite API contract (draft)
-/docs/bootstrap-helper.md   # Paste/upload helper contract (draft)
+/plans/libretto-product-strategy.md   # Product strategy and staircase
+/plans/tech-stack-guidelines.md       # Tech stack and workflow
+/docs/ddd/overview.md                 # DDD overview (mermaid diagrams)
+/cmd, /internal                       # Backend monolith (Go)
+/proto, /gen                          # Shared protobufs and generated code (Go/TS)
 ```
 
-## Spec-Driven Development
-- The spec is the single source of truth (see Section 5.0+6.0). All features tie to EARS FRs.
-- Changes flow: propose deltas in spec.md → update schemas/contracts → implement → tests/observability → CI.
+## Development workflow (short)
+- Keep domain logic in Go modules; expose Wails bindings
+- Author SQL and run sqlc for type-safe repositories
+- Maintain proto DTOs for UI boundary; generate TS clients via buf
 
-## Bootstrap (MVP)
-- Template-first wizard (Three-Act, Hero’s Journey to start) with archetypes
-- Optional paste/upload (Markdown/CSV/TXT) to fill in template fields
-- Human-in-the-loop review before applying to a bootstrap branch (versioned)
-
-## Exports (MVP)
-- Final copy: Markdown
-- Compendia: CSV/JSON/Markdown (story bible, character book, lore book)
+## Getting started
+- Build: `make build`  •  Test: `make test`
+- Run monolith: `make dev-up` (serves API + bindings)
+- UI (Wails): see ticket 00009 for scaffold plan
 
 ## Contributing
-- Open issues/PRs against spec.md before implementation changes
-- Follow the PR checklist in plans/execution-plan.md (schemas, tests, observability, IaC updates)
+- Discuss changes against strategy and tech stack docs first
+- Keep proto contracts and sqlc schema changes small and reviewed
 
 ## Security & privacy
 - Do not commit secrets. Use macOS Keychain or environment variables for local credentials.
-- All runtime secrets will be managed via GCP KMS and Terraform.
+- Local-first; no external services required. Future cloud features will be opt-in.
 
 ## License
 - TBA

--- a/docs/ddd/overview.md
+++ b/docs/ddd/overview.md
@@ -1,0 +1,84 @@
+# Domain-Driven Design Overview (MVP)
+
+Status: Proposed
+
+## Ubiquitous Language
+- Project: container for scenes and related narrative assets
+- Scene: atomic narrative unit with title, summary, content
+- Directive: user instruction to agents (text, act, target)
+- Scene Proposal: candidate scene derived from a directive
+
+## Bounded Contexts
+- Creation: directive -> proposal
+- Narrative Graph: storage, indexing, retrieval of scenes (later: acts/beats)
+- Rendering/Export: formats (later)
+
+## Module/Container View (Monolith)
+```mermaid
+flowchart TB
+  subgraph Monolith
+    App[internal/app Orchestrator]
+    Plot[internal/agents/plotweaver]
+    Narr[internal/agents/narrative]
+    Store[internal/graphwrite (Store + Repos)]
+    Ctx[internal/context (Context Manager: memory, RAG)]
+  end
+  UI[Desktop UI (Wails React)] <---> |Bindings + DTOs| App
+  App --> Plot
+  App --> Narr
+  App --> Ctx
+  Narr --> Store
+```
+
+## Domain Model (initial)
+```mermaid
+classDiagram
+  class Project {
+    UUID id
+    string name
+    +AddScene(Scene)
+    +ListScenes()
+  }
+  class Scene {
+    UUID id
+    string title
+    string summary
+    string content
+  }
+  Project "1" o-- "*" Scene
+```
+
+## Directive → Persisted Scene (Sequence)
+```mermaid
+sequenceDiagram
+  participant UI
+  participant App as Orchestrator
+  participant Plot as PlotWeaver
+  participant Ctx as ContextMgr
+  participant Narr as Narrative
+  participant Repo as Store(sqlc)
+  UI->>App: IssueDirective(DirectiveDTO)
+  App->>Ctx: BuildContext(project, directive)
+  Ctx-->>App: ContextBundle
+  App->>Plot: ProcessDirective(text, act, target, ContextBundle)
+  Plot-->>App: SceneProposal(domain)
+  App->>Narr: ApplySceneProposal(Store, proposal)
+  Narr->>Repo: CreateScene(id, title, summary, content)
+  Repo-->>Narr: ok
+  Narr-->>App: ok
+  App-->>UI: IssueDirectiveResponse(correlationId)
+```
+
+## Proto Seams (DTOs)
+- baton.v1: IssueDirectiveRequest/Response
+- scene.v1: Scene, SceneList
+- context.v1 (later): ContextBundle summary for debugging/telemetry
+
+## Notes on Context Management
+- Local Context Manager responsible for:
+  - Token budget planning per task
+  - Prompt assembly with domain-aware sections (beats, characters, prior scenes)
+  - RAG over local vector DB (scoped to project)
+  - Model selection policy (Ollama vs API providers)
+- Local vector DB options: SQLite+Vec (pgvecto.rs alt), Qdrant (embedded), or Milvus lite; start with sqlite-vec for fewer moving parts.
+

--- a/plans/tech-stack-guidelines.md
+++ b/plans/tech-stack-guidelines.md
@@ -1,0 +1,36 @@
+### **Tech Stack Guideline: Narrative Agent Application**
+
+**Last Updated:** 24 August 2025
+
+#### **1. Guiding Philosophy**
+
+This stack is optimized for a single developer to rapidly build a high-performance, cross-platform, local-first desktop application. Every choice prioritizes **speed of feature development**, reliability, and a clean separation of concerns, minimizing time spent on configuration, styling, and boilerplate.
+
+---
+
+#### **2. Core Technologies**
+
+| Layer | Technology | Rationale |
+| :--- | :--- | :--- |
+| **Backend Logic** | **Go** | **Performance & Concurrency.** Go's goroutines are perfectly suited for the multi-agent architecture. It compiles to a fast, single binary, ensuring a responsive core application. |
+| **Desktop Framework** | **Wails** | **The Go-to-UI Bridge.** Wails is a lightweight framework designed to wrap a Go backend with a web frontend. It's more memory-efficient than alternatives like Electron and provides seamless bindings between Go and JavaScript. |
+| **Frontend Framework** | **React** | **Maturity & Developer Familiarity.** A robust, mature library with a vast ecosystem. Your familiarity with React eliminates the learning curve, allowing you to build the UI immediately. |
+| **UI Components & Styling** | **shadcn/ui & Tailwind CSS** | **Maximum Development Velocity.** This is the key to not focusing on styling. `shadcn/ui` provides beautiful, accessible, copy-and-pasteable components. Tailwind CSS enables rapid styling directly in the markup. This combination drastically reduces the time required to build a polished UI. |
+| **Local Database** | **SQLite** | **Zero-Configuration & Reliability.** The ideal choice for a local-first application. The database is a single, portable file with no server process to manage. It's fast, robust, and battle-tested. |
+| **Database Interaction** | **sqlc** | **Type-Safe SQL.** `sqlc` generates fully type-safe, idiomatic Go code from your raw SQL queries. This gives you the safety of an ORM with the simplicity and performance of writing pure SQL, preventing common bugs and speeding up data layer development. |
+| **Context Management** | **Context Manager (Go)** | **Narrative-aware memory.** Builds task-scoped context bundles: token budgeting, prompt assembly (beats, characters, prior scenes), model selection. |
+| **Local Vector DB** | **sqlite-vec** | **RAG without new infra.** Embeddings stored in SQLite using the sqlite-vec extension enable fast local similarity search per project. |
+
+---
+
+#### **3. Development Workflow Summary**
+
+1.  **Backend:** Define core logic and agent behaviour in **Go**. Expose functions that can be called from the frontend.
+2.  **Database:** Write `CREATE TABLE` and query `.sql` files. Run **sqlc** to generate type-safe Go methods for database access.
+3.  **Frontend:** Use the **Wails** CLI to manage the project and run the development server.
+4.  **UI Construction:** Build React components. When a UI element is needed (e.g., a button, dialog, or data table), add it from **shadcn/ui** and style it instantly with **Tailwind CSS**.
+5.  **Integration:** Call Go functions directly from your React components via the Wails bridge to interact with the backend and the SQLite database.
+6.  **Context/RAG:** Chunk and embed relevant documents (scenes, notes); store vectors with sqlite-vec; query via a Retriever to assemble task-specific context.
+7.  **Model Selection:** Use a simple policy (task, complexity, budget) to choose between local Ollama and user-provided API keys.
+
+This stack provides a cohesive and powerful environment, allowing you to focus your energy where it matters most: building a great product.

--- a/plans/tickets/00007-ddd-overview-and-context-manager-foundation.md
+++ b/plans/tickets/00007-ddd-overview-and-context-manager-foundation.md
@@ -1,0 +1,31 @@
+# 00007 – DDD overview and Context Manager foundation
+
+Status: Proposed
+Owner: barrynorthern
+
+## Context
+We’ve pivoted to a modular monolith with Wails+React and a local-first strategy. The primary differentiator is effective context management (task-specific memory + RAG + model selection). We need a DDD doc and an initial Context Manager seam.
+
+## Goal
+- Author a DDD document (mermaid diagrams) capturing bounded contexts, modules, domain model, and the directive→scene sequence with context.
+- Introduce an internal/context package with interfaces for Context Builder, Retrieval, and Model Selection (no heavy implementation yet).
+
+## Scope
+- Docs
+  - docs/ddd/overview.md with mermaid: container/module, class diagram, sequence
+- Code
+  - internal/context: package skeleton with interfaces:
+    - Builder: Build(projectID, directive) -> ContextBundle
+    - Retriever: Search(projectID, query, k) -> []Result
+    - ModelSelector: Choose(task, complexity, budget) -> ModelSpec
+  - Choose vector DB: sqlite-vec (preferred for simplicity). Add TODO placeholder; implement in follow-up.
+
+## Acceptance criteria
+- DDD doc present with the three diagrams
+- internal/context package compiles with interfaces and TODOs
+
+## Out of scope
+- Full RAG implementation
+- Embedding pipeline and chunking
+- Model registry and selection policies (stubs only)
+

--- a/plans/tickets/00008-local-vector-db-and-rag-pipeline.md
+++ b/plans/tickets/00008-local-vector-db-and-rag-pipeline.md
@@ -1,0 +1,29 @@
+# 00008 – Local vector DB (sqlite-vec) and RAG pipeline (MVP)
+
+Status: Proposed
+Owner: barrynorthern
+
+## Context
+Context management requires local retrieval for project-scoped memory. To minimize dependencies, use SQLite with sqlite-vec for embeddings and similarity search.
+
+## Goal
+Implement a minimal RAG pipeline using sqlite-vec:
+- Schema: documents(project_id, doc_id, kind, text, embedding BLOB)
+- Functions: upsert embedding; search k-NN by cosine or L2
+- Integrate Retriever interface from internal/context
+
+## Scope
+- Add sqlite-vec dependency and migration
+- Create embedding pipeline stub (choose provider via config; Ollama or local CPU model first)
+- Implement internal/context/sqlitev retriever (Search)
+- Unit tests with small vectors to validate k-NN results
+
+## Acceptance criteria
+- Build/test green with sqlite-vec enabled locally
+- Retriever.Search returns expected nearest neighbors on fixture data
+- Basic upsert and search demonstrated in a test
+
+## Out of scope
+- Full document chunker, advanced ranking, or caching
+- Cross-project/global memory
+

--- a/plans/tickets/00009-wails-desktop-scaffold-and-shadcn-setup.md
+++ b/plans/tickets/00009-wails-desktop-scaffold-and-shadcn-setup.md
@@ -1,0 +1,24 @@
+# 00009 – Wails desktop scaffold and shadcn/Tailwind setup
+
+Status: Proposed
+Owner: barrynorthern
+
+## Context
+We will ship a local-first desktop experience using Wails with a React frontend and shadcn/ui + Tailwind for fast, consistent UI.
+
+## Goal
+Scaffold the Wails app and a minimal UI page that invokes a Go binding.
+
+## Scope
+- Initialize Wails project under apps/desktop
+- Set up React + Tailwind + shadcn/ui
+- Create a "Scenes" page that calls a Go binding ListScenes() and renders results
+- Add Make targets for wails dev/build
+
+## Acceptance criteria
+- `make desktop-dev` launches Wails dev window
+- Scenes page renders with shadcn components and calls a Go binding
+
+## Out of scope
+- Advanced routing, state management, theming beyond defaults
+


### PR DESCRIPTION
## Problem
- Our docs and plan over-optimized for distributed complexity and under-specified the real differentiator: local context management (task-aware memory, model selection, RAG).
- Strategy and tech choices were scattered; README duplicated outdated details and didn’t reflect the pivot.
- Without a shared domain model, we risk rework and ad‑hoc seams as we implement the monolith and desktop app.

## Solution
- Anchor on why we’re building this: add a concise DDD overview to align mental models and enforce clean domain seams (proto at the edges, Go in the core).
- Elevate context as a first-class concern: introduce tickets centered on Context Manager and a local vector DB (sqlite‑vec) so we solve the hard part users actually feel.
- Simplify communication: point README to strategy and tech‑stack docs; update the stack to include context/RAG so future work stays coherent.
